### PR TITLE
feat: add stdio transport support with configurable transport protocol

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,3 +53,4 @@ jobs:
         with:
           name: python-packages
           path: build/
+          if-no-files-found: error

--- a/.kiro/specs/oscal-mcp-server/design.md
+++ b/.kiro/specs/oscal-mcp-server/design.md
@@ -18,7 +18,7 @@ graph TB
     
     subgraph "MCP Protocol Layer"
         B[FastMCP Server]
-        C[MCP Transport - streamable-http]
+        C[MCP Transport - stdio/streamable-http]
     end
     
     subgraph "Application Layer"
@@ -69,9 +69,10 @@ graph TB
 **Responsibilities:**
 - Initialize and configure the FastMCP server
 - Register OSCAL tools with the MCP framework
-- Handle command line argument parsing
+- Handle command line argument parsing including transport selection
 - Configure logging and error handling
-- Manage server lifecycle
+- Manage server lifecycle with appropriate transport protocol
+- Validate and configure transport method (stdio or streamable-http)
 
 **Key Interfaces:**
 ```python
@@ -99,6 +100,7 @@ class Config:
     aws_region: str | None
     log_level: str
     server_name: str
+    transport: str  # "stdio" or "streamable-http"
     
     def update_from_args(self, **kwargs) -> None
 ```
@@ -182,6 +184,7 @@ class ServerConfig:
     aws_region: str | None = None
     log_level: str = "INFO"
     server_name: str = "OSCAL MCP Server"
+    transport: str = "stdio"  # Default to stdio transport
 ```
 
 ### OSCAL Model Information
@@ -279,15 +282,39 @@ Property 12: Input Validation Consistency\
 
 Property 13: Schema File System Consistency\
 *For any* supported model type and schema format, the corresponding schema file should exist in the expected location with the correct naming convention\
-**Validates: Requirements 7.2, 7.3, 7.4**
+**Validates: Requirements 8.2, 8.3, 8.4**
 
 Property 14: Schema JSON Format Validation\
 *For any* schema returned by get_oscal_schema, the response should be a valid JSON string that can be parsed without errors\
-**Validates: Requirements 7.6**
+**Validates: Requirements 8.6**
 
 Property 15: File Error Handling\
 *For any* file operation that fails (file not found, permission denied, etc.), the server should provide descriptive error messages\
+**Validates: Requirements 8.5**
+
+Property 16: Transport Protocol Support\
+*For any* supported transport type ("stdio" or "streamable-http"), the server should start successfully and use the specified transport protocol\
+**Validates: Requirements 5.4, 7.3, 7.4**
+
+Property 17: Transport Configuration Override\
+*For any* explicit transport configuration, the server should use that transport instead of the default stdio transport\
+**Validates: Requirements 5.6**
+
+Property 18: Command Line Transport Argument\
+*For any* valid transport type provided via --transport argument, the server should parse and apply that configuration correctly\
+**Validates: Requirements 7.1**
+
+Property 19: Invalid Transport Error Handling\
+*For any* invalid transport type specification, the server should return an error message listing the valid transport options\
 **Validates: Requirements 7.5**
+
+Property 20: Transport Validation Before Startup\
+*For any* transport configuration, the server should validate the transport type before attempting to start the server\
+**Validates: Requirements 7.6**
+
+Property 21: Transport Method Logging\
+*For any* server startup, the selected transport method should be logged during the initialization process\
+**Validates: Requirements 7.7**
 
 ## Error Handling
 

--- a/.kiro/specs/oscal-mcp-server/requirements.md
+++ b/.kiro/specs/oscal-mcp-server/requirements.md
@@ -80,10 +80,12 @@ This document specifies the requirements for an MCP (Model Context Protocol) ser
 1. THE MCP_Server SHALL implement the FastMCP framework for MCP protocol compliance
 2. THE MCP_Server SHALL register all OSCAL tools with the MCP framework
 3. THE MCP_Server SHALL provide tool schemas that describe parameters and return types
-4. THE MCP_Server SHALL support streamable-http transport for communication
-5. THE MCP_Server SHALL include descriptive instructions about OSCAL and server capabilities
-6. WHEN tools are invoked, THE MCP_Server SHALL pass context information including session parameters
-7. THE MCP_Server SHALL handle MCP protocol errors and provide appropriate responses
+4. THE MCP_Server SHALL support both stdio and streamable-http transport protocols
+5. THE MCP_Server SHALL use stdio transport as the default communication method
+6. WHEN streamable-http transport is explicitly configured, THE MCP_Server SHALL use streamable-http instead of stdio
+7. THE MCP_Server SHALL include descriptive instructions about OSCAL and server capabilities
+8. WHEN tools are invoked, THE MCP_Server SHALL pass context information including session parameters
+9. THE MCP_Server SHALL handle MCP protocol errors and provide appropriate responses
 
 ### Requirement 6: Error Handling and Logging
 
@@ -99,7 +101,21 @@ This document specifies the requirements for an MCP (Model Context Protocol) ser
 6. THE MCP_Server SHALL support DEBUG, INFO, WARNING, and ERROR log levels
 7. WHEN invalid parameters are provided, THE MCP_Server SHALL validate inputs and return clear error messages
 
-### Requirement 7: Schema File Management
+### Requirement 7: Transport Configuration
+
+**User Story:** As a system administrator, I want to configure the MCP transport method, so that I can choose between stdio and HTTP-based communication based on my deployment needs.
+
+#### Acceptance Criteria
+
+1. THE MCP_Server SHALL accept a --transport command line argument to specify the transport type
+2. WHEN --transport is not specified, THE MCP_Server SHALL default to stdio transport
+3. WHEN --transport is set to "stdio", THE MCP_Server SHALL use standard input/output for communication
+4. WHEN --transport is set to "streamable-http", THE MCP_Server SHALL use HTTP-based transport
+5. WHEN an invalid transport type is specified, THE MCP_Server SHALL return an error with valid options
+6. THE MCP_Server SHALL validate transport configuration before starting the server
+7. THE MCP_Server SHALL log the selected transport method during startup
+
+### Requirement 8: Schema File Management
 
 **User Story:** As a developer, I want the server to manage OSCAL schema files locally, so that schema retrieval is fast and reliable without external dependencies.
 

--- a/.kiro/specs/oscal-mcp-server/tasks.md
+++ b/.kiro/specs/oscal-mcp-server/tasks.md
@@ -154,10 +154,57 @@ This implementation plan reflects the current state of the OSCAL MCP Server impl
   - Tag tests with feature and property information
   - _Requirements: All requirements covered by correctness properties_
 
-- [ ] 12. Final integration verification
+- [x] 12. Add stdio transport support to configuration
+  - Add transport field to Config class with default value "stdio"
+  - Update config.py to handle transport configuration from environment and CLI args
+  - Add --transport command line argument to argument parser
+  - Add transport validation logic to ensure only valid values are accepted
+  - _Requirements: 7.1, 7.2, 7.5, 7.6_
+
+- [ ]* 12.1 Write property tests for transport configuration
+  - **Property 18: Command Line Transport Argument**
+  - **Validates: Requirements 7.1**
+
+- [ ]* 12.2 Write property tests for transport validation
+  - **Property 19: Invalid Transport Error Handling**
+  - **Property 20: Transport Validation Before Startup**
+  - **Validates: Requirements 7.5, 7.6**
+
+- [x] 13. Update main server to support both transport types
+  - Modify main() function to use configured transport instead of hardcoded "streamable-http"
+  - Add transport selection logic based on configuration
+  - Add transport method logging during startup
+  - Update error handling for transport-specific failures
+  - _Requirements: 5.4, 5.5, 5.6, 7.3, 7.4, 7.7_
+
+- [ ]* 13.1 Write property tests for transport protocol support
+  - **Property 16: Transport Protocol Support**
+  - **Property 17: Transport Configuration Override**
+  - **Validates: Requirements 5.4, 5.6, 7.3, 7.4**
+
+- [ ]* 13.2 Write property tests for transport logging
+  - **Property 21: Transport Method Logging**
+  - **Validates: Requirements 7.7**
+
+- [x] 14. Update unit tests for transport functionality
+  - Add tests for transport configuration parsing
+  - Add tests for transport validation logic
+  - Add tests for main() function with different transport options
+  - Update existing tests to work with new transport parameter
+  - _Requirements: 7.1, 7.2, 7.3, 7.4, 7.5, 7.6, 7.7_
+
+- [ ] 15. Add missing property-based tests using Hypothesis
+  - Install and configure Hypothesis for property-based testing
+  - Implement the 21 correctness properties identified in the design
+  - Ensure each property test runs minimum 100 iterations
+  - Tag tests with feature and property information
+  - _Requirements: All requirements covered by correctness properties_
+
+- [ ] 16. Final integration verification
   - Ensure all tests pass including new property-based tests
-  - Verify end-to-end functionality works correctly
-  - Test MCP server can start and respond to tool calls
+  - Verify end-to-end functionality works correctly with both transports
+  - Test MCP server can start with stdio transport (default)
+  - Test MCP server can start with streamable-http transport (explicit)
   - Validate all error handling paths work as expected
 
 ## Notes
@@ -171,14 +218,15 @@ This implementation plan reflects the current state of the OSCAL MCP Server impl
 
 ## Summary
 
-**Implementation Status: ~95% Complete**
+**Implementation Status: ~85% Complete**
 
-The OSCAL MCP Server implementation is nearly complete with all core functionality implemented and comprehensive unit test coverage. The main remaining work involves:
+The OSCAL MCP Server implementation has all core functionality implemented but needs stdio transport support added. The main remaining work involves:
 
 1. ✅ **RESOLVED**: Import path issues have been fixed - 90/91 tests now pass
-2. **Enhancement**: Adding property-based tests to validate the 15 correctness properties  
-3. **Minor Fix**: One failing test in error logging behavior (non-critical)
-4. **Verification**: Final integration testing
+2. **New Feature**: Add stdio transport support and make it the default
+3. **Enhancement**: Adding property-based tests to validate the 21 correctness properties  
+4. **Minor Fix**: One failing test in error logging behavior (non-critical)
+5. **Verification**: Final integration testing with both transport types
 
 **Key Accomplishments:**
 - ✅ All three MCP tools fully implemented (query_documentation, list_models, get_schema)
@@ -191,7 +239,9 @@ The OSCAL MCP Server implementation is nearly complete with all core functionali
 
 **Immediate Next Steps:**
 1. ✅ **COMPLETED**: Import paths fixed - tests now running successfully
-2. Add Hypothesis for property-based testing
-3. Implement the 15 correctness properties as property tests
-4. Fix minor test failure (optional)
-5. Verify end-to-end functionality
+2. Add stdio transport support to configuration and main server
+3. Update unit tests for new transport functionality
+4. Add Hypothesis for property-based testing
+5. Implement the 21 correctness properties as property tests
+6. Fix minor test failure (optional)
+7. Verify end-to-end functionality with both transport types

--- a/dotenv.example
+++ b/dotenv.example
@@ -14,3 +14,6 @@ export LOG_LEVEL=INFO
 
 # Server Configuration 
 # OSCAL_MCP_SERVER_NAME=OSCAL
+
+# MCP transport (defaults to stdio)
+# OSCAL_MCP_TRANSPORT=streamable-http

--- a/src/mcp_server_for_oscal/config.py
+++ b/src/mcp_server_for_oscal/config.py
@@ -18,8 +18,7 @@ class Config:
 
         # Bedrock configuration (can be overridden by command line args)
         self.bedrock_model_id: str = os.getenv(
-            "BEDROCK_MODEL_ID",
-            "us.anthropic.claude-sonnet-4-20250514-v1:0"
+            "BEDROCK_MODEL_ID", "us.anthropic.claude-sonnet-4-20250514-v1:0"
         )
 
         # Knowledge base configuration (can be overridden by command line args)
@@ -33,9 +32,18 @@ class Config:
         self.log_level: str = os.getenv("LOG_LEVEL", "INFO")
 
         # Server configuration
-        self.server_name: str = os.getenv("OSCAL_MCP_SERVER_NAME", "OSCAL MCP Server")
+        self.server_name: str = os.getenv("OSCAL_MCP_SERVER_NAME", "OSCAL")
 
-    def update_from_args(self, bedrock_model_id: str | None = None, knowledge_base_id: str | None = None, log_level: str | None = None) -> None:
+        # Transport configuration
+        self.transport: str = os.getenv("OSCAL_MCP_TRANSPORT", "stdio")
+
+    def update_from_args(
+        self,
+        bedrock_model_id: str | None = None,
+        knowledge_base_id: str | None = None,
+        log_level: str | None = None,
+        transport: str | None = None,
+    ) -> None:
         """Update configuration with command line arguments."""
         if bedrock_model_id:
             self.bedrock_model_id = bedrock_model_id
@@ -43,6 +51,21 @@ class Config:
             self.knowledge_base_id = knowledge_base_id
         if log_level:
             self.log_level = log_level
+        if transport:
+            self.transport = transport
+
+    def validate_transport(self) -> None:
+        """Validate that the configured transport is supported.
+
+        Raises:
+            ValueError: If transport is not one of the valid options.
+        """
+        valid_transports = ["stdio", "streamable-http"]
+        if self.transport not in valid_transports:
+            raise ValueError(
+                f"Invalid transport type: {self.transport}. "
+                f"Valid options are: {', '.join(valid_transports)}"
+            )
 
 
 # Global configuration instance

--- a/src/mcp_server_for_oscal/oscal_agent.py
+++ b/src/mcp_server_for_oscal/oscal_agent.py
@@ -1,4 +1,3 @@
-
 import boto3
 from strands import Agent
 from strands.models import BedrockModel

--- a/src/mcp_server_for_oscal/tools/get_schema.py
+++ b/src/mcp_server_for_oscal/tools/get_schema.py
@@ -14,8 +14,11 @@ from mcp_server_for_oscal.tools.utils import OSCALModelType
 
 logger = logging.getLogger(__name__)
 
+
 @tool
-def get_oscal_schema(ctx: Context, model_name: str = "complete", schema_type: str = "json") -> str:
+def get_oscal_schema(
+    ctx: Context, model_name: str = "complete", schema_type: str = "json"
+) -> str:
     """
     A tool that returns the schema for specified OSCAL model. Try this tool first for any questions about the structure of OSCAL models.
     By default we return a JSON schema, but `schema_type` parameter can change that behavior.
@@ -29,7 +32,10 @@ def get_oscal_schema(ctx: Context, model_name: str = "complete", schema_type: st
         str: The requested schema as JSON string
     """
     logger.debug(
-        "get_oscal_model_schema(model_name: %s, syntax: %s, session client params: %s)", model_name, schema_type, ctx.session.client_params
+        "get_oscal_model_schema(model_name: %s, syntax: %s, session client params: %s)",
+        model_name,
+        schema_type,
+        ctx.session.client_params,
     )
 
     if schema_type not in ["json", "xsd"]:
@@ -38,14 +44,19 @@ def get_oscal_schema(ctx: Context, model_name: str = "complete", schema_type: st
             garbage = ctx.error(msg)
         raise ValueError(msg)
 
-    if model_name not in OSCALModelType.__members__.values() and model_name != "complete":
+    if (
+        model_name not in OSCALModelType.__members__.values()
+        and model_name != "complete"
+    ):
         msg = f"Invalid model: {model_name}. Use the tool list_oscal_models to get valid model names."
         if ctx is not None:
             garbage = ctx.error(msg)
         raise ValueError(msg)
 
     model_name = model_name.replace(OSCALModelType.SYSTEM_SECURITY_PLAN, "ssp")
-    model_name = model_name.replace(OSCALModelType.PLAN_OF_ACTION_AND_MILESTONES, "poam")
+    model_name = model_name.replace(
+        OSCALModelType.PLAN_OF_ACTION_AND_MILESTONES, "poam"
+    )
 
     schema_file_name = f"oscal_{model_name}_schema.{schema_type}"
 

--- a/src/mcp_server_for_oscal/tools/list_models.py
+++ b/src/mcp_server_for_oscal/tools/list_models.py
@@ -17,44 +17,44 @@ def list_oscal_models() -> dict:
     """
     models = {
         OSCALModelType.CATALOG: {
-            "description":"A structured set of controls and control enhancements",
+            "description": "A structured set of controls and control enhancements",
             "layer": "Control",
-            "status": "GA"
+            "status": "GA",
         },
         OSCALModelType.PROFILE: {
             "description": "A baseline or overlay that selects and customizes controls from catalogs",
             "layer": "Control",
-            "status": "GA"
+            "status": "GA",
         },
         OSCALModelType.MAPPING: {
             "description": "Describes how a collection of security controls relates to another collection of controls",
             "layer": "Control",
-            "status": "PROTOTYPE"
+            "status": "PROTOTYPE",
         },
         OSCALModelType.COMPONENT_DEFINITION: {
             "description": "Describes how components implement controls",
             "layer": "Implementation",
-            "status": "GA"
+            "status": "GA",
         },
         OSCALModelType.SYSTEM_SECURITY_PLAN: {
             "description": "Documents how a system implements required controls",
             "layer": "Implementation",
-            "status": "GA"
+            "status": "GA",
         },
         OSCALModelType.ASSESSMENT_PLAN: {
             "description": "Defines how controls will be assessed",
             "layer": "Assessment",
-            "status": "GA"
+            "status": "GA",
         },
         OSCALModelType.ASSESSMENT_RESULTS: {
             "description": "Documents the results of control assessments",
             "layer": "Assessment",
-            "status": "GA"
+            "status": "GA",
         },
         OSCALModelType.PLAN_OF_ACTION_AND_MILESTONES: {
             "description": "Documents remediation plans for identified issues",
             "layer": "Assessment",
-            "status": "GA"
+            "status": "GA",
         },
     }
 

--- a/src/mcp_server_for_oscal/tools/query_documentation.py
+++ b/src/mcp_server_for_oscal/tools/query_documentation.py
@@ -64,6 +64,7 @@ def query_kb(query: str, ctx: Context) -> Any:
             garbage = ctx.error(msg)
         raise
 
+
 def query_local(query: str, ctx: Context) -> Any:
     msg = "Not yet implemented"
     logger.error(msg)

--- a/src/mcp_server_for_oscal/tools/utils.py
+++ b/src/mcp_server_for_oscal/tools/utils.py
@@ -22,4 +22,3 @@ class OSCALModelType(StrEnum):
     ASSESSMENT_RESULTS = "assessment-results"
     PLAN_OF_ACTION_AND_MILESTONES = "plan-of-action-and-milestones"
     MAPPING = "mapping-collection"
-

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -13,15 +13,18 @@ class TestConfig:
 
     def test_config_initialization_with_defaults(self):
         """Test that config initializes with default values when env vars are not set."""
-        with patch.dict(os.environ, {"PYTHON_DOTENV_DISABLED":"1"}, clear=True):
+        with patch.dict(os.environ, {"PYTHON_DOTENV_DISABLED": "1"}, clear=True):
             config = Config()
 
-            assert config.bedrock_model_id == "us.anthropic.claude-sonnet-4-20250514-v1:0"
+            assert (
+                config.bedrock_model_id == "us.anthropic.claude-sonnet-4-20250514-v1:0"
+            )
             assert config.knowledge_base_id == ""
             assert config.aws_profile is None
             assert config.aws_region is None
             assert config.log_level == "INFO"
-            assert config.server_name == "OSCAL MCP Server"
+            assert config.server_name == "OSCAL"
+            assert config.transport == "stdio"
 
     def test_config_initialization_with_env_vars(self):
         """Test that config loads values from environment variables."""
@@ -32,7 +35,7 @@ class TestConfig:
             "AWS_REGION": "us-west-2",
             "LOG_LEVEL": "DEBUG",
             "OSCAL_MCP_SERVER_NAME": "Custom OSCAL Server",
-            "PYTHON_DOTENV_DISABLED":"1"
+            "PYTHON_DOTENV_DISABLED": "1",
         }
 
         with patch.dict(os.environ, env_vars, clear=True):
@@ -44,6 +47,7 @@ class TestConfig:
             assert config.aws_region == "us-west-2"
             assert config.log_level == "DEBUG"
             assert config.server_name == "Custom OSCAL Server"
+            assert config.transport == "stdio"  # Default since not in env_vars
 
     def test_update_from_args_all_params(self):
         """Test updating configuration from command line arguments."""
@@ -52,7 +56,7 @@ class TestConfig:
         config.update_from_args(
             bedrock_model_id="new-model-id",
             knowledge_base_id="new-kb-id",
-            log_level="WARNING"
+            log_level="WARNING",
         )
 
         assert config.bedrock_model_id == "new-model-id"
@@ -79,18 +83,110 @@ class TestConfig:
         original_log_level = config.log_level
 
         config.update_from_args(
-            bedrock_model_id=None,
-            knowledge_base_id=None,
-            log_level=None
+            bedrock_model_id=None, knowledge_base_id=None, log_level=None
         )
 
         assert config.bedrock_model_id == original_model_id
         assert config.knowledge_base_id == original_kb_id
         assert config.log_level == original_log_level
 
-
-    @patch('mcp_server_for_oscal.config.load_dotenv')
+    @patch("mcp_server_for_oscal.config.load_dotenv")
     def test_dotenv_loading(self, mock_load_dotenv):
         """Test that dotenv is loaded during initialization."""
         Config()
         mock_load_dotenv.assert_called_once()
+
+    def test_transport_default_value(self):
+        """Test that transport defaults to stdio."""
+        with patch.dict(os.environ, {"PYTHON_DOTENV_DISABLED": "1"}, clear=True):
+            config = Config()
+            assert config.transport == "stdio"
+
+    def test_transport_from_env_var(self):
+        """Test that transport can be set via environment variable."""
+        env_vars = {
+            "OSCAL_MCP_TRANSPORT": "streamable-http",
+            "PYTHON_DOTENV_DISABLED": "1",
+        }
+        with patch.dict(os.environ, env_vars, clear=True):
+            config = Config()
+            assert config.transport == "streamable-http"
+
+    def test_update_from_args_with_transport(self):
+        """Test updating transport from command line arguments."""
+        config = Config()
+        config.update_from_args(transport="streamable-http")
+        assert config.transport == "streamable-http"
+
+    def test_validate_transport_stdio(self):
+        """Test that stdio transport passes validation."""
+        config = Config()
+        config.transport = "stdio"
+        config.validate_transport()  # Should not raise
+
+    def test_validate_transport_streamable_http(self):
+        """Test that streamable-http transport passes validation."""
+        config = Config()
+        config.transport = "streamable-http"
+        config.validate_transport()  # Should not raise
+
+    def test_validate_transport_invalid(self):
+        """Test that invalid transport raises ValueError."""
+        config = Config()
+        config.transport = "invalid-transport"
+
+        try:
+            config.validate_transport()
+            assert False, "Expected ValueError to be raised"
+        except ValueError as e:
+            assert "Invalid transport type: invalid-transport" in str(e)
+            assert "Valid options are: stdio, streamable-http" in str(e)
+
+    def test_validate_transport_case_sensitive(self):
+        """Test that transport validation is case sensitive."""
+        config = Config()
+        config.transport = "STDIO"
+
+        try:
+            config.validate_transport()
+            assert False, "Expected ValueError to be raised for uppercase transport"
+        except ValueError as e:
+            assert "Invalid transport type: STDIO" in str(e)
+            assert "Valid options are: stdio, streamable-http" in str(e)
+
+    def test_validate_transport_empty_string(self):
+        """Test that empty string transport raises ValueError."""
+        config = Config()
+        config.transport = ""
+
+        try:
+            config.validate_transport()
+            assert False, "Expected ValueError to be raised for empty transport"
+        except ValueError as e:
+            assert "Invalid transport type: " in str(e)
+            assert "Valid options are: stdio, streamable-http" in str(e)
+
+    def test_validate_transport_none(self):
+        """Test that None transport raises error."""
+        config = Config()
+        config.transport = None
+
+        try:
+            config.validate_transport()
+            assert False, "Expected error to be raised for None transport"
+        except (ValueError, TypeError):
+            # Either ValueError or TypeError is acceptable for None
+            pass
+
+    def test_update_from_args_empty_string_transport(self):
+        """Test updating transport with empty string (should not update)."""
+        config = Config()
+        original_transport = config.transport
+
+        config.update_from_args(transport="")
+        assert (
+            config.transport == original_transport
+        )  # Should NOT update with empty string
+
+        # Original transport should still be valid
+        config.validate_transport()  # Should not raise

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -22,11 +22,10 @@ class TestIntegration:
         assert isinstance(mcp, FastMCP)
 
         # Verify server has the expected name
-        assert mcp.name == "OSCAL MCP Server"  # Default from config
+        assert mcp.name == "OSCAL"  # Default from config
 
         # Verify server has instructions
         assert mcp.instructions is not None
-        assert "OSCAL MCP Server" in mcp.instructions
         assert "OSCAL" in mcp.instructions
 
     def test_mcp_server_tools_registration(self):
@@ -43,11 +42,13 @@ class TestIntegration:
         expected_tools = [
             "query_oscal_documentation",
             "list_oscal_models",
-            "get_oscal_schema"
+            "get_oscal_schema",
         ]
 
         for expected_tool in expected_tools:
-            assert expected_tool in tool_names, f"Tool {expected_tool} not found in registered tools"
+            assert expected_tool in tool_names, (
+                f"Tool {expected_tool} not found in registered tools"
+            )
 
     def test_mcp_server_tool_schemas(self):
         """Test that registered tools have proper schemas."""
@@ -55,7 +56,7 @@ class TestIntegration:
 
         for tool_name, tool in tools.items():
             # Verify tool has a schema
-            assert hasattr(tool, 'schema'), f"Tool {tool_name} missing schema"
+            assert hasattr(tool, "schema"), f"Tool {tool_name} missing schema"
 
             # Verify schema has required fields
             # schema = tool.model_json_schema()
@@ -68,9 +69,11 @@ class TestIntegration:
             # # Verify description is not empty
             # assert schema['description'].strip(), f"Tool {tool_name} has empty description"
 
-    @patch('mcp_server_for_oscal.tools.query_documentation.Session')
-    @patch('mcp_server_for_oscal.tools.query_documentation.config')
-    def test_query_documentation_tool_integration(self, mock_config, mock_session_class):
+    @patch("mcp_server_for_oscal.tools.query_documentation.Session")
+    @patch("mcp_server_for_oscal.tools.query_documentation.config")
+    def test_query_documentation_tool_integration(
+        self, mock_config, mock_session_class
+    ):
         """Test integration of query_documentation tool."""
         # Setup mocks
         mock_config.aws_profile = None
@@ -80,11 +83,8 @@ class TestIntegration:
         mock_session = Mock()
         mock_client = Mock()
         mock_response = {
-            'retrievalResults': [
-                {
-                    'content': {'text': 'Test OSCAL content'},
-                    'score': 0.9
-                }
+            "retrievalResults": [
+                {"content": {"text": "Test OSCAL content"}, "score": 0.9}
             ]
         }
         mock_client.retrieve.return_value = mock_response
@@ -98,11 +98,11 @@ class TestIntegration:
 
         # Verify result
         assert result == mock_response
-        assert 'retrievalResults' in result
-        assert len(result['retrievalResults']) > 0
+        assert "retrievalResults" in result
+        assert len(result["retrievalResults"]) > 0
 
-    @patch('mcp_server_for_oscal.tools.get_schema.open_schema_file')
-    @patch('mcp_server_for_oscal.tools.get_schema.json.load')
+    @patch("mcp_server_for_oscal.tools.get_schema.open_schema_file")
+    @patch("mcp_server_for_oscal.tools.get_schema.json.load")
     def test_get_schema_tool_integration(self, mock_json_load, mock_open_schema_file):
         """Test integration of get_schema tool."""
         # Setup mocks
@@ -116,10 +116,13 @@ class TestIntegration:
         mock_context.session.client_params = {}
 
         # Execute tool
-        result = get_oscal_schema(mock_context, model_name="catalog", schema_type="json")
+        result = get_oscal_schema(
+            mock_context, model_name="catalog", schema_type="json"
+        )
 
         # Verify result
         import json
+
         parsed_result = json.loads(result)
         assert parsed_result == mock_schema
         assert "$schema" in parsed_result
@@ -136,14 +139,14 @@ class TestIntegration:
         # Verify each model has expected structure
         for model_name, model_info in result.items():
             assert isinstance(model_info, dict)
-            assert 'description' in model_info
-            assert 'layer' in model_info
-            assert 'status' in model_info
+            assert "description" in model_info
+            assert "layer" in model_info
+            assert "status" in model_info
 
             # Verify values are not empty
-            assert model_info['description'].strip()
-            assert model_info['layer'].strip()
-            assert model_info['status'].strip()
+            assert model_info["description"].strip()
+            assert model_info["layer"].strip()
+            assert model_info["status"].strip()
 
     def test_mcp_server_instructions_content(self):
         """Test that MCP server instructions contain expected content."""
@@ -151,18 +154,20 @@ class TestIntegration:
 
         # Verify key content is present
         expected_content = [
-            "OSCAL MCP Server",
+            "OSCAL MCP server",
             "OSCAL",
             "Open Security Controls Assessment Language",
             "NIST",
             "security",
-            "controls"
+            "controls",
         ]
 
         for content in expected_content:
-            assert content in instructions, f"Expected content '{content}' not found in instructions"
+            assert content in instructions, (
+                f"Expected content '{content}' not found in instructions"
+            )
 
-    @patch('mcp_server_for_oscal.main.config')
+    @patch("mcp_server_for_oscal.main.config")
     def test_mcp_server_configuration_integration(self, mock_config):
         """Test that MCP server uses configuration properly."""
         # Test with custom server name
@@ -170,10 +175,8 @@ class TestIntegration:
 
         # Create new MCP instance with custom config
         from mcp_server_for_oscal.main import FastMCP
-        custom_mcp = FastMCP(
-            mock_config.server_name,
-            instructions="Test instructions"
-        )
+
+        custom_mcp = FastMCP(mock_config.server_name, instructions="Test instructions")
 
         # Verify custom name is used
         assert custom_mcp.name == "Custom OSCAL Server"
@@ -185,15 +188,15 @@ class TestIntegration:
         # Test query_documentation signature
         sig = inspect.signature(query_oscal_documentation)
         params = list(sig.parameters.keys())
-        assert 'query' in params
-        assert 'ctx' in params
+        assert "query" in params
+        assert "ctx" in params
 
         # Test get_schema signature
         sig = inspect.signature(get_oscal_schema)
         params = list(sig.parameters.keys())
-        assert 'ctx' in params
-        assert 'model_name' in params
-        assert 'schema_type' in params
+        assert "ctx" in params
+        assert "model_name" in params
+        assert "schema_type" in params
 
         # Test list_models signature
         sig = inspect.signature(list_oscal_models)
@@ -205,16 +208,22 @@ class TestIntegration:
 
         # Check query_documentation has @tool decorator
         # This is indicated by the presence of certain attributes added by the decorator
-        assert hasattr(query_oscal_documentation, '__wrapped__') or hasattr(query_oscal_documentation, '_tool_metadata')
+        assert hasattr(query_oscal_documentation, "__wrapped__") or hasattr(
+            query_oscal_documentation, "_tool_metadata"
+        )
 
         # Check get_schema has @tool decorator
-        assert hasattr(get_oscal_schema, '__wrapped__') or hasattr(get_oscal_schema, '_tool_metadata')
+        assert hasattr(get_oscal_schema, "__wrapped__") or hasattr(
+            get_oscal_schema, "_tool_metadata"
+        )
 
         # Check list_models has @tool decorator
-        assert hasattr(list_oscal_models, '__wrapped__') or hasattr(list_oscal_models, '_tool_metadata')
+        assert hasattr(list_oscal_models, "__wrapped__") or hasattr(
+            list_oscal_models, "_tool_metadata"
+        )
 
-    @patch('mcp_server_for_oscal.tools.query_documentation.Session')
-    @patch('mcp_server_for_oscal.tools.query_documentation.config')
+    @patch("mcp_server_for_oscal.tools.query_documentation.Session")
+    @patch("mcp_server_for_oscal.tools.query_documentation.config")
     def test_error_handling_integration(self, mock_config, mock_session_class):
         """Test error handling across integrated components."""
         # Setup mocks to simulate AWS error
@@ -223,16 +232,17 @@ class TestIntegration:
         mock_config.log_level = "INFO"
 
         from botocore.exceptions import ClientError
+
         error_response = {
-            'Error': {
-                'Code': 'ResourceNotFoundException',
-                'Message': 'Knowledge base not found'
+            "Error": {
+                "Code": "ResourceNotFoundException",
+                "Message": "Knowledge base not found",
             }
         }
 
         mock_session = Mock()
         mock_client = Mock()
-        mock_client.retrieve.side_effect = ClientError(error_response, 'Retrieve')
+        mock_client.retrieve.side_effect = ClientError(error_response, "Retrieve")
         mock_session.client.return_value = mock_client
         mock_session_class.return_value = mock_session
 
@@ -249,19 +259,19 @@ class TestIntegration:
         """Test that MCP server is compatible with expected transports."""
         # Verify server can be configured for streamable-http transport
         # This is tested by checking that the server has the necessary methods
-        assert hasattr(mcp, 'run'), "MCP server missing run method"
+        assert hasattr(mcp, "run"), "MCP server missing run method"
 
         # The actual transport compatibility is tested in the main function tests
         # Here we just verify the server structure supports it
 
-    @patch('mcp_server_for_oscal.tools.get_schema.open_schema_file')
+    @patch("mcp_server_for_oscal.tools.get_schema.open_schema_file")
     def test_schema_file_integration(self, mock_open_schema_file):
         """Test integration with schema file system."""
         # Test that schema files are accessed correctly
         mock_file = Mock()
         mock_open_schema_file.return_value = mock_file
 
-        with patch('mcp_server_for_oscal.tools.get_schema.json.load') as mock_json_load:
+        with patch("mcp_server_for_oscal.tools.get_schema.json.load") as mock_json_load:
             mock_json_load.return_value = {"test": "schema"}
 
             mock_context = Mock()
@@ -285,9 +295,11 @@ class TestIntegration:
         import logging
 
         # Verify loggers exist for key components
-        config_logger = logging.getLogger('mcp_server_for_oscal.config')
-        main_logger = logging.getLogger('mcp_server_for_oscal.main')
-        tools_logger = logging.getLogger('mcp_server_for_oscal.tools.query_documentation')
+        config_logger = logging.getLogger("mcp_server_for_oscal.config")
+        main_logger = logging.getLogger("mcp_server_for_oscal.main")
+        tools_logger = logging.getLogger(
+            "mcp_server_for_oscal.tools.query_documentation"
+        )
 
         # Verify loggers are properly configured (they should exist)
         assert config_logger is not None
@@ -308,10 +320,10 @@ class TestIntegration:
         )
 
         # Verify key components exist
-        assert hasattr(main, 'main')
-        assert hasattr(main, 'mcp')
-        assert hasattr(config, 'config')
-        assert hasattr(query_documentation, 'query_oscal_documentation')
-        assert hasattr(get_schema, 'get_oscal_schema')
-        assert hasattr(list_models, 'list_oscal_models')
-        assert hasattr(utils, 'OSCALModelType')
+        assert hasattr(main, "main")
+        assert hasattr(main, "mcp")
+        assert hasattr(config, "config")
+        assert hasattr(query_documentation, "query_oscal_documentation")
+        assert hasattr(get_schema, "get_oscal_schema")
+        assert hasattr(list_models, "list_oscal_models")
+        assert hasattr(utils, "OSCALModelType")

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -27,15 +27,16 @@ class TestMain:
         mcp.run = Mock()
         return mcp
 
-    @patch('mcp_server_for_oscal.main.mcp')
-    @patch('mcp_server_for_oscal.main.config')
-    @patch('mcp_server_for_oscal.main.logging.basicConfig')
-    @patch('sys.argv', ['main.py'])
+    @patch("mcp_server_for_oscal.main.mcp")
+    @patch("mcp_server_for_oscal.main.config")
+    @patch("mcp_server_for_oscal.main.logging.basicConfig")
+    @patch("sys.argv", ["main.py"])
     def test_main_default_arguments(self, mock_logging_config, mock_config, mock_mcp):
         """Test main function with default arguments."""
         # Setup mocks
         mock_config.aws_profile = "default"
         mock_config.log_level = "INFO"
+        mock_config.transport = "stdio"
 
         # Execute test
         main()
@@ -44,30 +45,42 @@ class TestMain:
         mock_config.update_from_args.assert_called_once_with(
             bedrock_model_id=None,
             knowledge_base_id=None,
-            log_level="INFO"
+            log_level="INFO",
+            transport="stdio",
         )
+
+        # Verify transport validation was called
+        mock_config.validate_transport.assert_called_once()
 
         # Verify logging configuration
         mock_logging_config.assert_called_once_with(level="INFO")
 
-        # Verify MCP server was started
-        mock_mcp.run.assert_called_once_with(transport="streamable-http")
+        # Verify MCP server was started with configured transport
+        mock_mcp.run.assert_called_once_with(transport="stdio")
 
-    @patch('mcp_server_for_oscal.main.mcp')
-    @patch('mcp_server_for_oscal.main.config')
-    @patch('mcp_server_for_oscal.main.logging.basicConfig')
-    @patch('sys.argv', [
-        'main.py',
-        '--aws-profile', 'test-profile',
-        '--log-level', 'DEBUG',
-        '--bedrock-model-id', 'test-model',
-        '--knowledge-base-id', 'test-kb'
-    ])
+    @patch("mcp_server_for_oscal.main.mcp")
+    @patch("mcp_server_for_oscal.main.config")
+    @patch("mcp_server_for_oscal.main.logging.basicConfig")
+    @patch(
+        "sys.argv",
+        [
+            "main.py",
+            "--aws-profile",
+            "test-profile",
+            "--log-level",
+            "DEBUG",
+            "--bedrock-model-id",
+            "test-model",
+            "--knowledge-base-id",
+            "test-kb",
+        ],
+    )
     def test_main_with_arguments(self, mock_logging_config, mock_config, mock_mcp):
         """Test main function with command line arguments."""
         # Setup mocks
         mock_config.aws_profile = "test-profile"
         mock_config.log_level = "DEBUG"
+        mock_config.transport = "stdio"
 
         # Execute test
         main()
@@ -76,26 +89,32 @@ class TestMain:
         mock_config.update_from_args.assert_called_once_with(
             bedrock_model_id="test-model",
             knowledge_base_id="test-kb",
-            log_level="DEBUG"
+            log_level="DEBUG",
+            transport="stdio",
         )
+
+        # Verify transport validation was called
+        mock_config.validate_transport.assert_called_once()
 
         # Verify logging configuration
         mock_logging_config.assert_called_once_with(level="DEBUG")
 
-        # Verify MCP server was started
-        mock_mcp.run.assert_called_once_with(transport="streamable-http")
+        # Verify MCP server was started with configured transport
+        mock_mcp.run.assert_called_once_with(transport="stdio")
 
-
-    @patch('mcp_server_for_oscal.main.mcp')
-    @patch('mcp_server_for_oscal.main.config')
-    @patch('mcp_server_for_oscal.main.logging.basicConfig')
-    @patch('mcp_server_for_oscal.main.logger')
-    @patch('sys.argv', ['main.py'])
-    def test_main_mcp_server_error(self, mock_logger, mock_logging_config, mock_config, mock_mcp):
+    @patch("mcp_server_for_oscal.main.mcp")
+    @patch("mcp_server_for_oscal.main.config")
+    @patch("mcp_server_for_oscal.main.logging.basicConfig")
+    @patch("mcp_server_for_oscal.main.logger")
+    @patch("sys.argv", ["main.py"])
+    def test_main_mcp_server_error(
+        self, mock_logger, mock_logging_config, mock_config, mock_mcp
+    ):
         """Test main function when MCP server fails to start."""
         # Setup mocks
         mock_config.aws_profile = "default"
         mock_config.log_level = "INFO"
+        mock_config.transport = "stdio"
 
         # Make MCP server fail
         mock_mcp.run.side_effect = Exception("Server failed to start")
@@ -104,21 +123,24 @@ class TestMain:
         with pytest.raises(Exception, match="Server failed to start"):
             main()
 
-        # Verify error was logged
+        # Verify error was logged with transport info
         mock_logger.exception.assert_called_once()
         error_call_args = mock_logger.exception.call_args[0][0]
         assert "Error running MCP server" in error_call_args
 
-    @patch('mcp_server_for_oscal.main.logging.getLogger')
-    @patch('mcp_server_for_oscal.main.mcp')
-    @patch('mcp_server_for_oscal.main.config')
-    @patch('mcp_server_for_oscal.main.logging.basicConfig')
-    @patch('sys.argv', ['main.py', '--log-level', 'DEBUG'])
-    def test_main_logger_configuration(self, mock_logging_config, mock_config, mock_mcp, mock_get_logger):
+    @patch("mcp_server_for_oscal.main.logging.getLogger")
+    @patch("mcp_server_for_oscal.main.mcp")
+    @patch("mcp_server_for_oscal.main.config")
+    @patch("mcp_server_for_oscal.main.logging.basicConfig")
+    @patch("sys.argv", ["main.py", "--log-level", "DEBUG"])
+    def test_main_logger_configuration(
+        self, mock_logging_config, mock_config, mock_mcp, mock_get_logger
+    ):
         """Test that all loggers are configured with the specified log level."""
         # Setup mocks
         mock_config.aws_profile = "default"
         mock_config.log_level = "DEBUG"
+        mock_config.transport = "stdio"
 
         mock_strands_logger = Mock()
         mock_mcp_logger = Mock()
@@ -143,11 +165,13 @@ class TestMain:
         mock_mcp_logger.setLevel.assert_called_once_with("DEBUG")
         mock_main_logger.setLevel.assert_called_once_with("DEBUG")
 
-    @patch('mcp_server_for_oscal.main.argparse.ArgumentParser')
-    @patch('mcp_server_for_oscal.main.mcp')
-    @patch('mcp_server_for_oscal.main.config')
-    @patch('mcp_server_for_oscal.main.logging.basicConfig')
-    def test_main_argument_parser_setup(self, mock_logging_config, mock_config, mock_mcp, mock_parser_class):
+    @patch("mcp_server_for_oscal.main.argparse.ArgumentParser")
+    @patch("mcp_server_for_oscal.main.mcp")
+    @patch("mcp_server_for_oscal.main.config")
+    @patch("mcp_server_for_oscal.main.logging.basicConfig")
+    def test_main_argument_parser_setup(
+        self, mock_logging_config, mock_config, mock_mcp, mock_parser_class
+    ):
         """Test that argument parser is set up correctly."""
         # Setup mocks
         mock_parser = Mock()
@@ -156,12 +180,14 @@ class TestMain:
         mock_args.log_level = "INFO"
         mock_args.bedrock_model_id = None
         mock_args.knowledge_base_id = None
+        mock_args.transport = "stdio"
 
         mock_parser.parse_args.return_value = mock_args
         mock_parser_class.return_value = mock_parser
 
         mock_config.aws_profile = "test-profile"
         mock_config.log_level = "INFO"
+        mock_config.transport = "stdio"
 
         # Execute test
         main()
@@ -177,27 +203,31 @@ class TestMain:
             "--aws-profile",
             "--log-level",
             "--bedrock-model-id",
-            "--knowledge-base-id"
+            "--knowledge-base-id",
+            "--transport",
         ]
 
         for expected_arg in expected_arguments:
             assert expected_arg in argument_names, f"Argument {expected_arg} not found"
 
-    @patch('sys.argv', ['main.py', '--help'])
+    @patch("sys.argv", ["main.py", "--help"])
     def test_main_help_argument(self):
         """Test that help argument works (will cause SystemExit)."""
         with pytest.raises(SystemExit):
             main()
 
-    @patch('mcp_server_for_oscal.main.mcp')
-    @patch('mcp_server_for_oscal.main.config')
-    @patch('mcp_server_for_oscal.main.logging.basicConfig')
-    @patch('sys.argv', ['main.py', '--log-level', 'INVALID'])
-    def test_main_with_invalid_log_level(self, mock_logging_config, mock_config, mock_mcp):
+    @patch("mcp_server_for_oscal.main.mcp")
+    @patch("mcp_server_for_oscal.main.config")
+    @patch("mcp_server_for_oscal.main.logging.basicConfig")
+    @patch("sys.argv", ["main.py", "--log-level", "INVALID"])
+    def test_main_with_invalid_log_level(
+        self, mock_logging_config, mock_config, mock_mcp
+    ):
         """Test main function with invalid log level (should still work)."""
         # Setup mocks
         mock_config.aws_profile = "default"
         mock_config.log_level = "INVALID"
+        mock_config.transport = "stdio"
 
         # Execute test (should not raise exception)
         main()
@@ -206,8 +236,191 @@ class TestMain:
         mock_config.update_from_args.assert_called_once_with(
             bedrock_model_id=None,
             knowledge_base_id=None,
-            log_level="INVALID"
+            log_level="INVALID",
+            transport="stdio",
         )
 
         # Verify logging was configured with invalid level
         mock_logging_config.assert_called_once_with(level="INVALID")
+
+    @patch("mcp_server_for_oscal.main.mcp")
+    @patch("mcp_server_for_oscal.main.config")
+    @patch("mcp_server_for_oscal.main.logging.basicConfig")
+    @patch("sys.argv", ["main.py", "--transport", "streamable-http"])
+    def test_main_with_streamable_http_transport(
+        self, mock_logging_config, mock_config, mock_mcp
+    ):
+        """Test main function with streamable-http transport."""
+        # Setup mocks
+        mock_config.aws_profile = "default"
+        mock_config.log_level = "INFO"
+        mock_config.transport = "streamable-http"
+
+        # Execute test
+        main()
+
+        # Verify configuration update was called with streamable-http transport
+        mock_config.update_from_args.assert_called_once_with(
+            bedrock_model_id=None,
+            knowledge_base_id=None,
+            log_level="INFO",
+            transport="streamable-http",
+        )
+
+        # Verify transport validation was called
+        mock_config.validate_transport.assert_called_once()
+
+        # Verify MCP server was started with streamable-http transport
+        mock_mcp.run.assert_called_once_with(transport="streamable-http")
+
+    @patch("mcp_server_for_oscal.main.mcp")
+    @patch("mcp_server_for_oscal.main.config")
+    @patch("mcp_server_for_oscal.main.logging.basicConfig")
+    @patch("mcp_server_for_oscal.main.logger")
+    @patch("sys.argv", ["main.py", "--transport", "invalid-transport"])
+    def test_main_with_invalid_transport(
+        self, mock_logger, mock_logging_config, mock_config, mock_mcp
+    ):
+        """Test main function with invalid transport type."""
+        # Setup mocks
+        mock_config.aws_profile = "default"
+        mock_config.log_level = "INFO"
+        mock_config.transport = "invalid-transport"
+
+        # Make validate_transport raise ValueError
+        mock_config.validate_transport.side_effect = ValueError(
+            "Invalid transport type: invalid-transport. "
+            "Valid options are: stdio, streamable-http"
+        )
+
+        # Execute test and verify SystemExit is raised
+        with pytest.raises(SystemExit) as exc_info:
+            main()
+
+        assert exc_info.value.code == 1
+
+        # Verify error was logged
+        mock_logger.error.assert_called_once()
+        error_call_args = mock_logger.error.call_args[0]
+        assert "Transport configuration error" in error_call_args[0]
+
+    @patch("mcp_server_for_oscal.main.mcp")
+    @patch("mcp_server_for_oscal.main.config")
+    @patch("mcp_server_for_oscal.main.logging.basicConfig")
+    @patch("mcp_server_for_oscal.main.logger")
+    @patch("sys.argv", ["main.py"])
+    def test_main_logs_transport_on_startup(
+        self, mock_logger, mock_logging_config, mock_config, mock_mcp
+    ):
+        """Test that transport method is logged during startup."""
+        # Setup mocks
+        mock_config.aws_profile = "default"
+        mock_config.log_level = "INFO"
+        mock_config.transport = "stdio"
+
+        # Execute test
+        main()
+
+        # Verify transport was logged during startup
+        mock_logger.info.assert_called()
+        info_calls = [call[0] for call in mock_logger.info.call_args_list]
+        transport_logged = any("transport" in str(call).lower() for call in info_calls)
+        assert transport_logged, "Transport method should be logged during startup"
+
+    @patch("mcp_server_for_oscal.main.mcp")
+    @patch("mcp_server_for_oscal.main.config")
+    @patch("mcp_server_for_oscal.main.logging.basicConfig")
+    @patch("sys.argv", ["main.py", "--transport", ""])
+    def test_main_with_empty_transport(
+        self, mock_logging_config, mock_config, mock_mcp
+    ):
+        """Test main function with empty transport string."""
+        # Setup mocks
+        mock_config.aws_profile = "default"
+        mock_config.log_level = "INFO"
+        mock_config.transport = ""
+
+        # Make validate_transport raise ValueError for empty string
+        mock_config.validate_transport.side_effect = ValueError(
+            "Invalid transport type: . Valid options are: stdio, streamable-http"
+        )
+
+        # Execute test and verify SystemExit is raised
+        with pytest.raises(SystemExit) as exc_info:
+            main()
+
+        assert exc_info.value.code == 1
+
+        # Verify configuration was updated with empty transport
+        mock_config.update_from_args.assert_called_once_with(
+            bedrock_model_id=None,
+            knowledge_base_id=None,
+            log_level="INFO",
+            transport="",
+        )
+
+    @patch("mcp_server_for_oscal.main.mcp")
+    @patch("mcp_server_for_oscal.main.config")
+    @patch("mcp_server_for_oscal.main.logging.basicConfig")
+    @patch("mcp_server_for_oscal.main.logger")
+    @patch("sys.argv", ["main.py", "--transport", "STDIO"])
+    def test_main_with_uppercase_transport(
+        self, mock_logger, mock_logging_config, mock_config, mock_mcp
+    ):
+        """Test main function with uppercase transport (should fail validation)."""
+        # Setup mocks
+        mock_config.aws_profile = "default"
+        mock_config.log_level = "INFO"
+        mock_config.transport = "STDIO"
+
+        # Make validate_transport raise ValueError for uppercase
+        mock_config.validate_transport.side_effect = ValueError(
+            "Invalid transport type: STDIO. Valid options are: stdio, streamable-http"
+        )
+
+        # Execute test and verify SystemExit is raised
+        with pytest.raises(SystemExit) as exc_info:
+            main()
+
+        assert exc_info.value.code == 1
+
+        # Verify error was logged
+        mock_logger.error.assert_called_once()
+        error_call_args = mock_logger.error.call_args[0]
+        assert "Transport configuration error" in error_call_args[0]
+
+    @patch("mcp_server_for_oscal.main.mcp")
+    @patch("mcp_server_for_oscal.main.config")
+    @patch("mcp_server_for_oscal.main.logging.basicConfig")
+    @patch("mcp_server_for_oscal.main.logger")
+    @patch("sys.argv", ["main.py"])
+    def test_main_logs_specific_transport_method(
+        self, mock_logger, mock_logging_config, mock_config, mock_mcp
+    ):
+        """Test that the specific transport method is logged with correct format."""
+        # Setup mocks
+        mock_config.aws_profile = "default"
+        mock_config.log_level = "INFO"
+        mock_config.transport = "streamable-http"
+
+        # Execute test
+        main()
+
+        # Verify specific transport was logged
+        mock_logger.info.assert_called()
+        info_calls = mock_logger.info.call_args_list
+
+        # Look for the specific log message about transport
+        transport_log_found = False
+        for call in info_calls:
+            if (
+                len(call[0]) >= 2
+                and "Starting OSCAL MCP Server with transport:" in call[0][0]
+            ):
+                assert call[0][1] == "streamable-http"
+                transport_log_found = True
+                break
+
+        assert transport_log_found, (
+            "Specific transport method should be logged during startup"
+        )


### PR DESCRIPTION
This commit implements configurable transport protocol support for the OSCAL MCP server, with stdio as the default transport method.

**Changes:**
- Add transport configuration to Config class with stdio as default
- Add --transport CLI argument and OSCAL_MCP_TRANSPORT env var support
- Add transport validation to ensure only stdio/streamable-http are allowed
- Update main server to use configured transport instead of hardcoded streamable-http
- Add transport method logging during server startup
- Improve error handling for transport-specific failures
- Update server name default to "OSCAL" and refine server instructions
- Add comprehensive unit tests for new transport functionality
- Update dotenv.example with transport configuration option
- Update project documentation and task tracking

**Technical Details:**
- Transport defaults to "stdio" for better MCP client compatibility
- Supports both "stdio" and "streamable-http" transport protocols
- Configuration can be overridden via CLI args or environment variables
- Includes proper validation and error reporting for invalid transport types

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
