### PR TITLE
Conditionally register query_oscal_documentation tool only when knowledge_base_id is configured

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,17 +42,15 @@ This MCP server communicates via stdio (standard input/output) and can be integr
 
 #### Configuration Format
 
-Most MCP-compatible tools use a JSON configuration format. *Values in the `env` section are generally not needed*, but shown here as a how-to. Here's the basic structure:
+Most MCP-compatible tools use a JSON configuration format. *Values in the `"env":` section are generally not needed*, but shown here as a how-to. Here's the basic structure:
 
 ```json
 {
   "mcpServers": {
     "oscal": {
-      "command": "python",
-      "args": ["-m", "mcp_server_for_oscal"],
+      "command": "uvx",
+      "args": ["--from", "https://github.com/awslabs/mcp-server-for-oscal/releases/latest", "server"],
       "env": {
-        "AWS_PROFILE": "your-aws-profile",
-        "AWS_REGION": "us-east-1"
       }
     }
   }
@@ -68,8 +66,8 @@ Add to your `.kiro/settings/mcp.json`:
 {
   "mcpServers": {
     "oscal": {
-      "command": "python",
-      "args": ["-m", "mcp_server_for_oscal"],
+      "command": "uvx",
+      "args": ["--from", "https://github.com/awslabs/mcp-server-for-oscal/releases/latest", "server"],
       "env": {
         "AWS_PROFILE": "your-aws-profile"
       },
@@ -87,8 +85,8 @@ Add to your `claude_desktop_config.json`:
 {
   "mcpServers": {
     "oscal": {
-      "command": "python",
-      "args": ["-m", "mcp_server_for_oscal"]
+      "command": "uvx",
+      "args": ["--from", "https://github.com/awslabs/mcp-server-for-oscal/releases/latest", "server"]
     }
   }
 }
@@ -102,8 +100,8 @@ Configure in your workspace settings or user settings:
   "mcp.servers": [
     {
       "name": "oscal",
-      "command": "python",
-      "args": ["-m", "mcp_server_for_oscal"]
+      "command": "uvx",
+      "args": ["--from", "https://github.com/awslabs/mcp-server-for-oscal/releases/latest", "server"]
     }
   ]
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,8 @@ dependencies = [
 ]
 requires-python = ">=3.11"
 description = "AI agent tools for Open Security Controls Assessment Language (OSCAL)."
+[project.scripts]
+server = "mcp_server_for_oscal.main:main"
 # dynamic = ["version"]
 
 # [tool.hatch.version]
@@ -135,7 +137,7 @@ update-awesome-oscal = [
   https://raw.githubusercontent.com/oscal-club/awesome-oscal/refs/heads/main/README.md''',
 ]
 
-server = ["python -m mcp_server_for_oscal.main"]
+http-server = ["python -m mcp_server_for_oscal.main --transport streamable-http"]
 
 [tool.hatch.envs.hatch-test.scripts]
 run = "pytest{env:HATCH_TEST_ARGS:} {args}"

--- a/src/mcp_server_for_oscal/main.py
+++ b/src/mcp_server_for_oscal/main.py
@@ -40,7 +40,11 @@ mcp = FastMCP(
 
 
 # Register tools with MCP server
-mcp.add_tool(query_oscal_documentation)
+# don't register the query_oscal_documentation tool unless we have a KB ID
+# TODO: get rid of this after we have working implementation of local index
+if config.knowledge_base_id is not None:
+    mcp.add_tool(query_oscal_documentation)
+
 mcp.add_tool(list_oscal_models)
 mcp.add_tool(get_oscal_schema)
 mcp.add_tool(list_oscal_resources)


### PR DESCRIPTION
- update installation instructions to use uvx and add CLI entry point
- Update README.md configuration examples across all MCP-compatible tools to use uvx with GitHub release URL instead of direct Python module invocation
- Add project.scripts entry point for "server" command in pyproject.toml to enable CLI usage
- Rename hatch script from "server" to "http-server" to clarify HTTP transport usage
- Conditionally register query_oscal_documentation tool only when knowledge_base_id is configured
- Improve documentation clarity by fixing env section formatting in configuration examples
- Simplifies installation and usage for end users by leveraging uvx for dependency management

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
