### PR TITLE
fix(tools): #84 Add offset/limit pagination to list tools

### DIFF
--- a/.kiro/specs/list-tools-pagination/.config.kiro
+++ b/.kiro/specs/list-tools-pagination/.config.kiro
@@ -1,0 +1,1 @@
+{"specId": "cf068add-22f4-47f4-92eb-03d1f37531cf", "workflowType": "requirements-first", "specType": "feature"}

--- a/.kiro/specs/list-tools-pagination/design.md
+++ b/.kiro/specs/list-tools-pagination/design.md
@@ -1,0 +1,228 @@
+# Design Document: list-tools-pagination
+
+## Overview
+
+This feature adds offset/limit pagination to the three list tools (`list_component_definitions`, `list_components`, `list_capabilities`) in the OSCAL MCP server. Today these tools return the entire result set at once, which can overflow an AI assistant's context window when many OSCAL artifacts are loaded.
+
+The design introduces a standalone `paginate()` helper function in `src/mcp_server_for_oscal/tools/utils.py` that slices any list into a page and returns a standardized response envelope. The `@tool()` wrappers are updated to accept `offset` and `limit` parameters, call the existing `ComponentDefinitionStore` list methods (unchanged), and pass the result through `paginate()`.
+
+### Design Decisions
+
+1. **Standalone function, not a method** — `paginate()` lives in `utils.py` so any future tool can reuse it without coupling to `ComponentDefinitionStore`.
+2. **No external pagination library** — Neither the `mcp` SDK (cursor-based protocol-layer pagination) nor `strands-agents` (`PaginatedList` is a return-type wrapper) provide an offset/limit slicing helper. A simple function is sufficient.
+3. **Pagination at the tool wrapper layer, not the store** — The `ComponentDefinitionStore` list methods remain unchanged (returning full `list[dict]`). Pagination is a presentation concern applied at the `@tool()` boundary. This keeps the store focused on data retrieval and avoids threading `offset`/`limit` through two layers for no benefit.
+4. **Defaults preserve usability** — `offset=0` and `limit=10` mean callers that omit pagination params get a small first page instead of the full set. `max_limit=100` prevents accidental context-window blowouts.
+5. **Return type changes from `list[dict]` to `dict`** — The new envelope (`items`, `total`, `offset`, `limit`, `hasMore`) is a breaking change to the tool response shape, but is necessary for callers to know whether more pages exist.
+
+## Architecture
+
+```mermaid
+flowchart LR
+    subgraph Tool Wrappers
+        LCD["list_component_definitions(ctx, offset, limit)"]
+        LC["list_components(ctx, offset, limit)"]
+        LCap["list_capabilities(ctx, offset, limit)"]
+    end
+
+    subgraph ComponentDefinitionStore
+        SLCD["list_component_definitions(ctx) → list[dict]"]
+        SLC["list_components(ctx) → list[dict]"]
+        SLCap["list_capabilities(ctx) → list[dict]"]
+    end
+
+    subgraph utils.py
+        P["paginate(items, offset, limit)"]
+    end
+
+    LCD --> SLCD
+    LCD --> P
+    LC --> SLC
+    LC --> P
+    LCap --> SLCap
+    LCap --> P
+```
+
+The flow is:
+1. Caller invokes a `@tool()` wrapper with optional `offset` and `limit`.
+2. The wrapper calls the corresponding `ComponentDefinitionStore` method, which returns the full `list[dict]` (unchanged).
+3. The wrapper passes the full list to `paginate(items, offset, limit)`.
+4. `paginate()` validates inputs, slices the list, and returns a `Page_Response` dict.
+
+## Components and Interfaces
+
+### `paginate()` — `src/mcp_server_for_oscal/tools/utils.py`
+
+```python
+def paginate(
+    items: list[dict],
+    offset: int = 0,
+    limit: int = 10,
+) -> dict:
+    """Slice a list into a single page and return a Page_Response envelope.
+
+    Args:
+        items: The full, ordered list of result dicts.
+        offset: Zero-based index of the first item to return.
+        limit: Maximum number of items to return (1–100).
+
+    Returns:
+        dict with keys: items, total, offset, limit, hasMore.
+
+    Raises:
+        ValueError: If offset < 0 or limit < 1 or limit > 100.
+    """
+```
+
+### `ComponentDefinitionStore` methods — unchanged
+
+The three list methods retain their current signatures and return types (`list[dict]`). No changes needed:
+
+```python
+def list_component_definitions(self, ctx: Context) -> list[dict]: ...
+def list_components(self, ctx: Context) -> list[dict]: ...
+def list_capabilities(self, ctx: Context) -> list[dict]: ...
+```
+
+### Updated `@tool()` wrappers
+
+Each wrapper gains `offset` and `limit` parameters, calls the store method for the full list, then applies `paginate()`:
+
+```python
+@tool()
+def list_component_definitions(
+    ctx: Context, offset: int = 0, limit: int = 10
+) -> dict:
+    items = _store.list_component_definitions(ctx)
+    return paginate(items, offset, limit)
+
+@tool()
+def list_components(
+    ctx: Context, offset: int = 0, limit: int = 10
+) -> dict:
+    items = _store.list_components(ctx)
+    return paginate(items, offset, limit)
+
+@tool()
+def list_capabilities(
+    ctx: Context, offset: int = 0, limit: int = 10
+) -> dict:
+    items = _store.list_capabilities(ctx)
+    return paginate(items, offset, limit)
+```
+
+## Data Models
+
+### Page_Response (returned dict)
+
+| Key | Type | Description |
+|---|---|---|
+| `items` | `list[dict]` | The sliced page of summary dicts. Same shape as current tool output items. |
+| `total` | `int` | Total number of items across all pages. |
+| `offset` | `int` | The offset that was used (including default). |
+| `limit` | `int` | The limit that was used (including default). |
+| `hasMore` | `bool` | `True` iff `offset + limit < total`. |
+
+### Input constraints
+
+| Parameter | Type | Default | Constraints |
+|---|---|---|---|
+| `offset` | `int` | `0` | Must be ≥ 0. |
+| `limit` | `int` | `10` | Must be ≥ 1 and ≤ 100. |
+
+### Item shapes (unchanged)
+
+The dicts inside `items` retain their current shapes:
+
+- **Component Definition summary**: `uuid`, `title`, `componentCount`, `importedComponentDefinitionsCount`, `sizeInBytes`
+- **Component summary**: `uuid`, `title`, `parentComponentDefinitionTitle`, `parentComponentDefinitionUuid`, `sizeInBytes`
+- **Capability summary**: `uuid`, `name`, `parentComponentDefinitionTitle`, `parentComponentDefinitionUuid`, `sizeInBytes`
+
+
+## Correctness Properties
+
+*A property is a characteristic or behavior that should hold true across all valid executions of a system — essentially, a formal statement about what the system should do. Properties serve as the bridge between human-readable specifications and machine-verifiable correctness guarantees.*
+
+The prework analysis identified that requirements 1.x, 2.x, and 3.x are largely redundant with each other because all three tools delegate to the same `paginate()` function. The consolidated properties below test `paginate()` directly, which covers all three tools. Integration-level examples verify that each tool correctly wires through to `paginate()`.
+
+### Property 1: Pagination round-trip
+
+*For any* list of dicts and *for any* valid limit (1–100), iterating through all pages by advancing offset by limit each time and concatenating the `items` from each page SHALL produce a list identical to the original input list in both content and order.
+
+**Validates: Requirements 4.4, 1.1, 2.1, 3.1, 5.2**
+
+### Property 2: Page size invariant
+
+*For any* list of dicts and *for any* valid offset (≥ 0) and limit (1–100), the number of items returned in `items` SHALL be less than or equal to `limit`.
+
+**Validates: Requirements 4.5, 1.1, 2.1, 3.1**
+
+### Property 3: hasMore correctness
+
+*For any* list of dicts and *for any* valid offset (≥ 0) and limit (1–100), `hasMore` SHALL be `True` if and only if `offset + limit < total`.
+
+**Validates: Requirements 4.6, 1.3, 2.3, 3.3**
+
+### Property 4: Response shape and metadata
+
+*For any* list of dicts and *for any* valid offset (≥ 0) and limit (1–100), the returned dict SHALL contain exactly the keys `items`, `total`, `offset`, `limit`, `hasMore`; `total` SHALL equal the length of the original input list; and `offset` and `limit` SHALL equal the values passed to `paginate()`.
+
+**Validates: Requirements 5.1, 5.3, 5.5, 1.3, 2.3, 3.3**
+
+### Property 5: Invalid inputs raise ValueError
+
+*For any* negative integer as offset, or *for any* limit outside the range [1, 100], calling `paginate()` SHALL raise a `ValueError`.
+
+**Validates: Requirements 4.3, 1.5, 1.6, 2.5, 2.6, 3.5, 3.6**
+
+### Property 6: Beyond-end offset yields empty page
+
+*For any* list of dicts and *for any* offset ≥ len(list) and *for any* valid limit (1–100), `items` SHALL be an empty list and `hasMore` SHALL be `False`.
+
+**Validates: Requirements 1.4, 2.4, 3.4**
+
+## Error Handling
+
+| Condition | Raised by | Exception | Message pattern |
+|---|---|---|---|
+| `offset < 0` | `paginate()` | `ValueError` | `"offset must be non-negative, got {offset}"` |
+| `limit < 1` | `paginate()` | `ValueError` | `"limit must be between 1 and 100, got {limit}"` |
+| `limit > 100` | `paginate()` | `ValueError` | `"limit must be between 1 and 100, got {limit}"` |
+| No component definitions loaded | `list_component_definitions()` | `RuntimeError` | `"No Component Definitions loaded"` (unchanged) |
+| No components loaded | `list_components()` | `RuntimeError` | `"No Components loaded"` (unchanged) |
+| No capabilities loaded | `list_capabilities()` | Returns empty page | `Page_Response` with `items=[], total=0, hasMore=False` (unchanged behavior — capabilities are optional) |
+
+Validation errors from `paginate()` propagate up through the tool wrappers unmodified. The existing `RuntimeError` behavior for empty stores is preserved — the store methods raise before `paginate()` is ever called.
+
+## Testing Strategy
+
+### Property-based tests (hypothesis)
+
+All six correctness properties are tested via `hypothesis` with a minimum of 100 examples each. Tests target the `paginate()` function directly since all three tools delegate to it.
+
+Each test is tagged with a comment referencing its design property:
+```
+# Feature: list-tools-pagination, Property {N}: {title}
+```
+
+Generators:
+- `items`: `st.lists(st.fixed_dictionaries({"id": st.integers()}))` — arbitrary-length lists of dicts
+- `offset`: `st.integers(min_value=0, max_value=200)` for valid; `st.integers(max_value=-1)` for invalid
+- `limit`: `st.integers(min_value=1, max_value=100)` for valid; `st.one_of(st.integers(max_value=0), st.integers(min_value=101))` for invalid
+
+Library: `hypothesis` (already in devtest dependencies)
+
+Configuration: `@settings(max_examples=100)` on each property test.
+
+### Unit tests (pytest)
+
+Unit tests cover concrete examples and integration points:
+
+1. **Default parameters** — each of the three tool wrappers called without `offset`/`limit` returns `offset=0, limit=10` in the response (validates requirements 1.2, 2.2, 3.2).
+2. **Empty capabilities** — `list_capabilities` with no data returns `Page_Response` with `items=[], total=0, hasMore=False` (validates requirement 3.7).
+3. **Integration smoke test** — each tool wrapper with a loaded fixture returns a valid `Page_Response` with correct `items` content, confirming the wiring from `@tool()` → `paginate()`.
+4. **Existing `TestListMethods` updates** — the existing tests in `tests/tools/test_query_component_definition.py` are updated to expect the new `dict` return type with `items` key instead of `list[dict]`. Store method tests remain unchanged since the store still returns `list[dict]`.
+
+### Test file locations
+
+- Property tests for `paginate()`: `tests/tools/test_paginate.py` (new file)
+- Unit tests for tool integration: updated in `tests/tools/test_query_component_definition.py` within `TestListMethods`

--- a/.kiro/specs/list-tools-pagination/requirements.md
+++ b/.kiro/specs/list-tools-pagination/requirements.md
@@ -1,0 +1,83 @@
+# Requirements Document
+
+## Introduction
+
+The `list_component_definitions`, `list_components`, and `list_capabilities` MCP tools in the `query_component_definition.py` module currently return all results at once. When many OSCAL Component Definitions, Components, or Capabilities are loaded, the full result set can overflow an AI assistant's context window. This feature adds offset/limit pagination to these three tools so callers can request results in manageable pages while preserving backward compatibility for callers that omit pagination parameters.
+
+## Glossary
+
+- **Pagination_Engine**: The internal pagination logic within `ComponentDefinitionStore` that slices a full result list into pages based on `offset` and `limit` parameters.
+- **List_Tool**: Any of the three MCP tool wrapper functions (`list_component_definitions`, `list_components`, `list_capabilities`) that delegate to the `ComponentDefinitionStore` singleton.
+- **Page_Response**: A dictionary returned by a paginated List_Tool containing the result slice and pagination metadata (`total`, `offset`, `limit`, `hasMore`).
+- **Store**: The `ComponentDefinitionStore` singleton instance that holds all indexed OSCAL data in memory.
+- **Offset**: A zero-based integer indicating how many items to skip from the beginning of the full result list.
+- **Limit**: A positive integer indicating the maximum number of items to return in a single page.
+- **Default_Limit**: The limit value applied when the caller does not supply an explicit `limit`. Set to 10.
+
+## Requirements
+
+### Requirement 1: Paginated list_component_definitions
+
+**User Story:** As an AI assistant, I want to request a page of Component Definition summaries, so that I can avoid overflowing my context window when many definitions are loaded.
+
+#### Acceptance Criteria
+
+1. WHEN `list_component_definitions` is called with `offset` and `limit` parameters, THE Pagination_Engine SHALL return at most `limit` items starting from position `offset` in the full result list.
+2. WHEN `list_component_definitions` is called without `offset` or `limit` parameters, THE List_Tool SHALL default `offset` to 0 and `limit` to Default_Limit.
+3. THE Page_Response SHALL include `total` (total number of Component Definitions), `offset` (the offset used), `limit` (the limit used), and `hasMore` (boolean indicating whether additional items exist beyond the current page).
+4. WHEN `offset` is greater than or equal to the total number of Component Definitions, THE Pagination_Engine SHALL return an empty `items` list with `hasMore` set to false.
+5. IF `offset` is negative, THEN THE Pagination_Engine SHALL raise a `ValueError` with a descriptive message.
+6. IF `limit` is less than 1 or greater than 100, THEN THE Pagination_Engine SHALL raise a `ValueError` with a descriptive message.
+
+### Requirement 2: Paginated list_components
+
+**User Story:** As an AI assistant, I want to request a page of Component summaries, so that I can avoid overflowing my context window when many components are loaded.
+
+#### Acceptance Criteria
+
+1. WHEN `list_components` is called with `offset` and `limit` parameters, THE Pagination_Engine SHALL return at most `limit` items starting from position `offset` in the full result list.
+2. WHEN `list_components` is called without `offset` or `limit` parameters, THE List_Tool SHALL default `offset` to 0 and `limit` to Default_Limit.
+3. THE Page_Response SHALL include `total`, `offset`, `limit`, and `hasMore` with the same semantics as Requirement 1.
+4. WHEN `offset` is greater than or equal to the total number of Components, THE Pagination_Engine SHALL return an empty `items` list with `hasMore` set to false.
+5. IF `offset` is negative, THEN THE Pagination_Engine SHALL raise a `ValueError` with a descriptive message.
+6. IF `limit` is less than 1 or greater than 100, THEN THE Pagination_Engine SHALL raise a `ValueError` with a descriptive message.
+
+### Requirement 3: Paginated list_capabilities
+
+**User Story:** As an AI assistant, I want to request a page of Capability summaries, so that I can avoid overflowing my context window when many capabilities are loaded.
+
+#### Acceptance Criteria
+
+1. WHEN `list_capabilities` is called with `offset` and `limit` parameters, THE Pagination_Engine SHALL return at most `limit` items starting from position `offset` in the full result list.
+2. WHEN `list_capabilities` is called without `offset` or `limit` parameters, THE List_Tool SHALL default `offset` to 0 and `limit` to Default_Limit.
+3. THE Page_Response SHALL include `total`, `offset`, `limit`, and `hasMore` with the same semantics as Requirement 1.
+4. WHEN `offset` is greater than or equal to the total number of Capabilities, THE Pagination_Engine SHALL return an empty `items` list with `hasMore` set to false.
+5. IF `offset` is negative, THEN THE Pagination_Engine SHALL raise a `ValueError` with a descriptive message.
+6. IF `limit` is less than 1 or greater than 100, THEN THE Pagination_Engine SHALL raise a `ValueError` with a descriptive message.
+7. WHEN no Capabilities are loaded, THE List_Tool SHALL return a Page_Response with an empty `items` list, `total` of 0, and `hasMore` set to false (no error raised, consistent with current behavior).
+
+### Requirement 4: Shared pagination logic
+
+**User Story:** As a developer, I want pagination logic centralized in a single reusable helper available to all tools in the project, so that any tool can paginate results consistently without duplicating logic.
+
+#### Acceptance Criteria
+
+1. THE Pagination_Engine SHALL be implemented as a standalone `paginate` function in `src/mcp_server_for_oscal/tools/utils.py`, reusable by any MCP tool in the project.
+2. THE Pagination_Engine SHALL accept a list of items, an `offset`, and a `limit`, and SHALL return a Page_Response dictionary.
+3. THE Pagination_Engine SHALL validate inputs: raise `ValueError` if `offset` is negative, or if `limit` is less than 1 or greater than 100.
+4. FOR ALL valid inputs, slicing then concatenating all pages SHALL produce the same items in the same order as the original unsliced list (round-trip property).
+5. FOR ALL valid `offset` and `limit` combinations, the number of items returned SHALL be less than or equal to `limit`.
+6. FOR ALL valid `offset` and `limit` combinations, `hasMore` SHALL be true if and only if `offset + limit < total`.
+7. THE implementation SHALL NOT depend on external pagination utilities (neither `mcp` SDK nor `strands-agents` provide a reusable offset/limit helper; the `mcp` SDK's pagination is cursor-based at the protocol layer, and Strands' `PaginatedList` is a return-type wrapper, not a slicing engine).
+
+### Requirement 5: Page_Response structure
+
+**User Story:** As an AI assistant, I want a consistent, predictable response shape from paginated list tools, so that I can reliably parse results and decide whether to fetch more pages.
+
+#### Acceptance Criteria
+
+1. THE Page_Response SHALL contain exactly these top-level keys: `items`, `total`, `offset`, `limit`, `hasMore`.
+2. THE `items` key SHALL contain the list of summary dictionaries for the current page (same shape as the items returned by the current non-paginated tools).
+3. THE `total` key SHALL contain the total count of all available items across all pages.
+4. THE `hasMore` key SHALL be a boolean value.
+5. THE `offset` and `limit` keys SHALL reflect the actual values used for the query (including defaults).

--- a/.kiro/specs/list-tools-pagination/tasks.md
+++ b/.kiro/specs/list-tools-pagination/tasks.md
@@ -1,0 +1,91 @@
+# Implementation Plan: list-tools-pagination
+
+## Overview
+
+Add offset/limit pagination to the three list tools by implementing a standalone `paginate()` helper in `utils.py`, updating the `@tool()` wrappers to accept `offset`/`limit` and return a `Page_Response` dict, and updating existing tests to match the new return type.
+
+## Tasks
+
+- [x] 1. Implement the `paginate()` helper function
+  - [x] 1.1 Add `paginate()` to `src/mcp_server_for_oscal/tools/utils.py`
+    - Accept `items: list[dict]`, `offset: int = 0`, `limit: int = 10`
+    - Validate: raise `ValueError` if `offset < 0`, `limit < 1`, or `limit > 100`
+    - Slice `items[offset:offset+limit]` and return a dict with keys `items`, `total`, `offset`, `limit`, `hasMore`
+    - `hasMore` is `True` iff `offset + limit < len(items)`
+    - _Requirements: 4.1, 4.2, 4.3, 4.4, 4.5, 4.6, 4.7, 5.1, 5.2, 5.3, 5.4, 5.5_
+
+  - [x] 1.2 Write property test: round-trip consistency (Property 1)
+    - **Property 1: Pagination round-trip**
+    - Iterate all pages by advancing offset by limit, concatenate `items` — must equal original list
+    - **Validates: Requirements 4.4, 1.1, 2.1, 3.1, 5.2**
+    - File: `tests/tools/test_paginate.py` (new), use `hypothesis` with `@settings(max_examples=100)`
+
+  - [x] 1.3 Write property test: page size invariant (Property 2)
+    - **Property 2: Page size invariant**
+    - `len(result["items"]) <= limit` for all valid inputs
+    - **Validates: Requirements 4.5, 1.1, 2.1, 3.1**
+
+  - [x] 1.4 Write property test: hasMore correctness (Property 3)
+    - **Property 3: hasMore correctness**
+    - `hasMore` is `True` iff `offset + limit < total`
+    - **Validates: Requirements 4.6, 1.3, 2.3, 3.3**
+
+  - [x] 1.5 Write property test: response shape and metadata (Property 4)
+    - **Property 4: Response shape and metadata**
+    - Returned dict has exactly keys `items`, `total`, `offset`, `limit`, `hasMore`; `total == len(input)`; `offset` and `limit` echo inputs
+    - **Validates: Requirements 5.1, 5.3, 5.5, 1.3, 2.3, 3.3**
+
+  - [x] 1.6 Write property test: invalid inputs raise ValueError (Property 5)
+    - **Property 5: Invalid inputs raise ValueError**
+    - Negative offset or limit outside [1, 100] raises `ValueError`
+    - **Validates: Requirements 4.3, 1.5, 1.6, 2.5, 2.6, 3.5, 3.6**
+
+  - [x] 1.7 Write property test: beyond-end offset yields empty page (Property 6)
+    - **Property 6: Beyond-end offset yields empty page**
+    - When `offset >= len(items)`, `items` is `[]` and `hasMore` is `False`
+    - **Validates: Requirements 1.4, 2.4, 3.4**
+
+- [x] 2. Checkpoint — Verify `paginate()` and property tests
+  - Ensure all tests pass, ask the user if questions arise.
+
+- [x] 3. Update `@tool()` wrappers with pagination parameters
+  - [x] 3.1 Update `list_component_definitions` wrapper in `src/mcp_server_for_oscal/tools/query_component_definition.py`
+    - Add `offset: int = 0` and `limit: int = 10` parameters
+    - Import `paginate` from `utils`
+    - Call `_store.list_component_definitions(ctx)` then `return paginate(items, offset, limit)`
+    - Update return type annotation from `list[dict]` to `dict`
+    - Update docstring to document `offset`, `limit`, and the `Page_Response` return shape
+    - _Requirements: 1.1, 1.2, 1.3, 1.4, 1.5, 1.6_
+
+  - [x] 3.2 Update `list_components` wrapper in `src/mcp_server_for_oscal/tools/query_component_definition.py`
+    - Same changes as 3.1 but for `list_components`
+    - _Requirements: 2.1, 2.2, 2.3, 2.4, 2.5, 2.6_
+
+  - [x] 3.3 Update `list_capabilities` wrapper in `src/mcp_server_for_oscal/tools/query_component_definition.py`
+    - Same changes as 3.1 but for `list_capabilities`
+    - _Requirements: 3.1, 3.2, 3.3, 3.4, 3.5, 3.6, 3.7_
+
+- [x] 4. Update existing tests for new return type
+  - [x] 4.1 Update `TestListMethods` in `tests/tools/test_query_component_definition.py`
+    - `test_list_component_definitions`: assert result is a `dict` with `items` key; check `result["items"][0]["title"]`, `total`, `offset`, `limit`, `hasMore`
+    - `test_list_component_definitions_empty`: unchanged (still raises `RuntimeError`)
+    - `test_list_components`: same pattern — unwrap via `result["items"]`
+    - `test_list_components_empty`: unchanged (still raises `RuntimeError`)
+    - `test_list_capabilities_empty`: assert result is a `Page_Response` with `items=[], total=0, hasMore=False`
+    - `test_list_capabilities_with_data`: unwrap via `result["items"]`
+    - _Requirements: 1.1, 1.2, 1.3, 2.1, 2.2, 2.3, 3.1, 3.2, 3.3, 3.7, 5.1_
+
+  - [x] 4.2 Add integration smoke tests for default pagination parameters
+    - Verify each wrapper called without `offset`/`limit` returns `offset=0, limit=10` in the response
+    - _Requirements: 1.2, 2.2, 3.2_
+
+- [x] 5. Final checkpoint — Ensure all tests pass
+  - Ensure all tests pass, ask the user if questions arise.
+
+## Notes
+
+- Tasks marked with `*` are optional and can be skipped for faster MVP
+- The `ComponentDefinitionStore` list methods are not modified — they keep returning `list[dict]`
+- All property tests target `paginate()` directly since all three tools delegate to it
+- `hypothesis` is already in devtest dependencies
+- Run tests with `hatch test` or `hatch run tests`

--- a/.kiro/specs/oscal-mcp-server/.config.kiro
+++ b/.kiro/specs/oscal-mcp-server/.config.kiro
@@ -1,0 +1,1 @@
+{"specId": "4bc8bbe7-23e8-47fa-a51f-ed0275d5a1eb", "workflowType": "requirements-first", "specType": "feature"}

--- a/src/mcp_server_for_oscal/tools/query_component_definition.py
+++ b/src/mcp_server_for_oscal/tools/query_component_definition.py
@@ -22,7 +22,7 @@ from strands import tool
 from trestle.oscal.component import Capability, ComponentDefinition, DefinedComponent
 
 from mcp_server_for_oscal.config import config
-from mcp_server_for_oscal.tools.utils import safe_log_mcp, try_notify_client_error
+from mcp_server_for_oscal.tools.utils import paginate, safe_log_mcp, try_notify_client_error
 
 logger = logging.getLogger(__name__)
 logger.setLevel(config.log_level)
@@ -673,8 +673,10 @@ def query_component_definition(
 
 
 @tool()
-def list_component_definitions(ctx: Context) -> list[dict]:
-    """List all loaded Component Definitions with summary metadata.
+def list_component_definitions(
+    ctx: Context, offset: int = 0, limit: int = 10
+) -> dict:
+    """List loaded Component Definitions with summary metadata.
 
     A Component Definition is the top-level OSCAL document that contains
     Capabilities and Components. Use this tool to discover available
@@ -683,18 +685,24 @@ def list_component_definitions(ctx: Context) -> list[dict]:
 
     Args:
         ctx: MCP server context (injected automatically by MCP server)
+        offset: Zero-based index of the first item to return (default 0).
+        limit: Maximum number of items to return, 1-100 (default 10).
 
     Returns:
-        list[dict]: One entry per Component Definition with keys:
+        dict: Page_Response with keys ``items``, ``total``, ``offset``,
+            ``limit``, ``hasMore``. Each item in ``items`` has keys:
             uuid, title, componentCount, importedComponentDefinitionsCount,
             sizeInBytes.
     """
-    return _store.list_component_definitions(ctx)
+    items = _store.list_component_definitions(ctx)
+    return paginate(items, offset, limit)
 
 
 @tool()
-def list_components(ctx: Context) -> list[dict]:
-    """List all loaded Components with summary metadata.
+def list_components(
+    ctx: Context, offset: int = 0, limit: int = 10
+) -> dict:
+    """List loaded Components with summary metadata.
 
     Components are leaf-level elements within a Component Definition that
     represent individual services, software, regions, or similar items.
@@ -704,35 +712,45 @@ def list_components(ctx: Context) -> list[dict]:
 
     Args:
         ctx: MCP server context (injected automatically by MCP server)
+        offset: Zero-based index of the first item to return (default 0).
+        limit: Maximum number of items to return, 1-100 (default 10).
 
     Returns:
-        list[dict]: One entry per Component with keys:
+        dict: Page_Response with keys ``items``, ``total``, ``offset``,
+            ``limit``, ``hasMore``. Each item in ``items`` has keys:
             uuid, title, parentComponentDefinitionTitle,
             parentComponentDefinitionUuid, sizeInBytes.
     """
-    return _store.list_components(ctx)
+    items = _store.list_components(ctx)
+    return paginate(items, offset, limit)
 
 @tool()
-def list_capabilities(ctx: Context) -> list[dict]:
-    """List all loaded Capabilities with summary metadata.
+def list_capabilities(
+    ctx: Context, offset: int = 0, limit: int = 10
+) -> dict:
+    """List loaded Capabilities with summary metadata.
 
-    Capabilities sit above Components but are optional in the OSCAL hierarchy. 
+    Capabilities sit above Components but are optional in the OSCAL hierarchy.
     Each Capability groups related Components and describes a collection
-    or higher-level offering. Start here when exploring what a Component Definition
-    provides — then drill into individual Components as needed.
+    or higher-level offering. Start here when exploring what a Component
+    Definition provides — then drill into individual Components as needed.
 
     Use the returned UUIDs or names as query_value in
     query_component_definition() to retrieve full Capability details.
 
     Args:
         ctx: MCP server context (injected automatically by MCP server)
+        offset: Zero-based index of the first item to return (default 0).
+        limit: Maximum number of items to return, 1-100 (default 10).
 
     Returns:
-        list[dict]: One entry per Capability with keys:
+        dict: Page_Response with keys ``items``, ``total``, ``offset``,
+            ``limit``, ``hasMore``. Each item in ``items`` has keys:
             uuid, name, parentComponentDefinitionTitle,
             parentComponentDefinitionUuid, sizeInBytes.
     """
-    return _store.list_capabilities(ctx)
+    items = _store.list_capabilities(ctx)
+    return paginate(items, offset, limit)
 
 @tool()
 def get_capability(ctx: Context, uuid: str) -> dict | None:

--- a/src/mcp_server_for_oscal/tools/utils.py
+++ b/src/mcp_server_for_oscal/tools/utils.py
@@ -182,3 +182,39 @@ def verify_package_integrity(directory: Path) -> None:
                 )
                 raise
             logger.debug("Hash for file %s matches", fn.name)
+
+
+def paginate(
+    items: list[dict],
+    offset: int = 0,
+    limit: int = 10,
+) -> dict:
+    """Slice a list into a single page and return a Page_Response envelope.
+
+    Args:
+        items: The full, ordered list of result dicts.
+        offset: Zero-based index of the first item to return.
+        limit: Maximum number of items to return (1-100).
+
+    Returns:
+        dict with keys: items, total, offset, limit, hasMore.
+
+    Raises:
+        ValueError: If offset < 0 or limit < 1 or limit > 100.
+    """
+    if offset < 0:
+        raise ValueError(f"offset must be non-negative, got {offset}")
+    if limit < 1 or limit > 100:
+        raise ValueError(f"limit must be between 1 and 100, got {limit}")
+
+    total = len(items)
+    sliced = items[offset : offset + limit]
+    has_more = offset + limit < total
+
+    return {
+        "items": sliced,
+        "total": total,
+        "offset": offset,
+        "limit": limit,
+        "hasMore": has_more,
+    }

--- a/tests/tools/test_paginate.py
+++ b/tests/tools/test_paginate.py
@@ -1,0 +1,125 @@
+"""Property-based tests for the paginate() helper function."""
+
+import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from mcp_server_for_oscal.tools.utils import paginate
+
+# Shared strategies
+items_strategy = st.lists(st.fixed_dictionaries({"id": st.integers()}))
+valid_offset = st.integers(min_value=0, max_value=200)
+valid_limit = st.integers(min_value=1, max_value=100)
+
+
+# Feature: list-tools-pagination, Property 1: Pagination round-trip
+class TestPaginationRoundTrip:
+    """Validates: Requirements 4.4, 1.1, 2.1, 3.1, 5.2"""
+
+    @given(items=items_strategy, limit=valid_limit)
+    @settings(max_examples=100)
+    def test_round_trip_concatenation_equals_original(self, items, limit):
+        """Iterating all pages and concatenating items reproduces the original list."""
+        collected = []
+        offset = 0
+        while True:
+            page = paginate(items, offset=offset, limit=limit)
+            collected.extend(page["items"])
+            if not page["hasMore"]:
+                break
+            offset += limit
+        assert collected == items
+
+
+# Feature: list-tools-pagination, Property 2: Page size invariant
+class TestPageSizeInvariant:
+    """Validates: Requirements 4.5, 1.1, 2.1, 3.1"""
+
+    @given(items=items_strategy, offset=valid_offset, limit=valid_limit)
+    @settings(max_examples=100)
+    def test_page_size_never_exceeds_limit(self, items, offset, limit):
+        """The number of items returned is always <= limit."""
+        result = paginate(items, offset=offset, limit=limit)
+        assert len(result["items"]) <= limit
+
+
+# Feature: list-tools-pagination, Property 3: hasMore correctness
+class TestHasMoreCorrectness:
+    """Validates: Requirements 4.6, 1.3, 2.3, 3.3"""
+
+    @given(items=items_strategy, offset=valid_offset, limit=valid_limit)
+    @settings(max_examples=100)
+    def test_has_more_iff_more_items_remain(self, items, offset, limit):
+        """hasMore is True iff offset + limit < total."""
+        result = paginate(items, offset=offset, limit=limit)
+        expected = offset + limit < len(items)
+        assert result["hasMore"] is expected
+
+
+# Feature: list-tools-pagination, Property 4: Response shape and metadata
+class TestResponseShapeAndMetadata:
+    """Validates: Requirements 5.1, 5.3, 5.5, 1.3, 2.3, 3.3"""
+
+    @given(items=items_strategy, offset=valid_offset, limit=valid_limit)
+    @settings(max_examples=100)
+    def test_response_has_exact_keys_and_correct_metadata(self, items, offset, limit):
+        """Response has exactly the required keys; total, offset, limit echo inputs."""
+        result = paginate(items, offset=offset, limit=limit)
+        assert set(result.keys()) == {"items", "total", "offset", "limit", "hasMore"}
+        assert result["total"] == len(items)
+        assert result["offset"] == offset
+        assert result["limit"] == limit
+
+
+# Feature: list-tools-pagination, Property 5: Invalid inputs raise ValueError
+class TestInvalidInputsRaiseValueError:
+    """Validates: Requirements 4.3, 1.5, 1.6, 2.5, 2.6, 3.5, 3.6"""
+
+    @given(
+        items=items_strategy,
+        offset=st.integers(max_value=-1),
+        limit=valid_limit,
+    )
+    @settings(max_examples=100)
+    def test_negative_offset_raises(self, items, offset, limit):
+        """Negative offset raises ValueError."""
+        with pytest.raises(ValueError):
+            paginate(items, offset=offset, limit=limit)
+
+    @given(
+        items=items_strategy,
+        offset=valid_offset,
+        limit=st.one_of(st.integers(max_value=0), st.integers(min_value=101)),
+    )
+    @settings(max_examples=100)
+    def test_invalid_limit_raises(self, items, offset, limit):
+        """Limit outside [1, 100] raises ValueError."""
+        with pytest.raises(ValueError):
+            paginate(items, offset=offset, limit=limit)
+
+
+# Feature: list-tools-pagination, Property 6: Beyond-end offset yields empty page
+class TestBeyondEndOffset:
+    """Validates: Requirements 1.4, 2.4, 3.4"""
+
+    @given(items=items_strategy, limit=valid_limit)
+    @settings(max_examples=100)
+    def test_offset_beyond_end_returns_empty_items_and_no_more(self, items, limit):
+        """When offset >= len(items), items is [] and hasMore is False."""
+        offset = len(items)  # exactly at the end
+        result = paginate(items, offset=offset, limit=limit)
+        assert result["items"] == []
+        assert result["hasMore"] is False
+
+    @given(
+        items=items_strategy,
+        extra=st.integers(min_value=1, max_value=200),
+        limit=valid_limit,
+    )
+    @settings(max_examples=100)
+    def test_offset_well_beyond_end_returns_empty(self, items, extra, limit):
+        """When offset > len(items), items is [] and hasMore is False."""
+        offset = len(items) + extra
+        result = paginate(items, offset=offset, limit=limit)
+        assert result["items"] == []
+        assert result["hasMore"] is False

--- a/tests/tools/test_query_component_definition.py
+++ b/tests/tools/test_query_component_definition.py
@@ -668,11 +668,17 @@ class TestListMethods:
 
     def test_list_component_definitions(self, mock_context, setup_store):
         result = list_component_definitions(mock_context)
-        assert len(result) == 1
-        assert result[0]["title"] == "Sample Component Definition"
-        assert "uuid" in result[0]
-        assert "componentCount" in result[0]
-        assert "sizeInBytes" in result[0]
+        assert isinstance(result, dict)
+        assert set(result.keys()) == {"items", "total", "offset", "limit", "hasMore"}
+        assert result["total"] == 1
+        assert result["offset"] == 0
+        assert result["limit"] == 10
+        assert result["hasMore"] is False
+        assert len(result["items"]) == 1
+        assert result["items"][0]["title"] == "Sample Component Definition"
+        assert "uuid" in result["items"][0]
+        assert "componentCount" in result["items"][0]
+        assert "sizeInBytes" in result["items"][0]
 
     def test_list_component_definitions_empty(self, mock_context):
         _store._reset()
@@ -681,9 +687,15 @@ class TestListMethods:
 
     def test_list_components(self, mock_context, setup_store):
         result = list_components(mock_context)
-        assert len(result) == 1
-        assert result[0]["title"] == "Sample Component"
-        assert "parentComponentDefinitionTitle" in result[0]
+        assert isinstance(result, dict)
+        assert set(result.keys()) == {"items", "total", "offset", "limit", "hasMore"}
+        assert result["total"] == 1
+        assert result["offset"] == 0
+        assert result["limit"] == 10
+        assert result["hasMore"] is False
+        assert len(result["items"]) == 1
+        assert result["items"][0]["title"] == "Sample Component"
+        assert "parentComponentDefinitionTitle" in result["items"][0]
 
     def test_list_components_empty(self, mock_context):
         _store._reset()
@@ -693,7 +705,12 @@ class TestListMethods:
     def test_list_capabilities_empty(self, mock_context):
         _store._reset()
         result = list_capabilities(mock_context)
-        assert result == []
+        assert isinstance(result, dict)
+        assert result["items"] == []
+        assert result["total"] == 0
+        assert result["offset"] == 0
+        assert result["limit"] == 10
+        assert result["hasMore"] is False
 
     def test_list_capabilities_with_data(self, mock_context, tmp_path, monkeypatch):
         _store._reset()
@@ -712,9 +729,94 @@ class TestListMethods:
         _store.load_from_directory(comp_defs_dir)
 
         result = list_capabilities(mock_context)
-        assert len(result) == 1
-        assert result[0]["name"] == "Test Capability"
-        assert "parentComponentDefinitionTitle" in result[0]
+        assert isinstance(result, dict)
+        assert set(result.keys()) == {"items", "total", "offset", "limit", "hasMore"}
+        assert result["total"] == 1
+        assert result["offset"] == 0
+        assert result["limit"] == 10
+        assert result["hasMore"] is False
+        assert len(result["items"]) == 1
+        assert result["items"][0]["name"] == "Test Capability"
+        assert "parentComponentDefinitionTitle" in result["items"][0]
+
+
+class TestDefaultPaginationParameters:
+    """Verify each wrapper returns offset=0, limit=10 when called without explicit params."""
+
+    @pytest.fixture
+    def mock_context(self):
+        ctx = AsyncMock()
+        ctx.log = AsyncMock()
+        return ctx
+
+    @pytest.fixture
+    def sample_component_def_data(self):
+        sample_path = (
+            Path(__file__).parent.parent
+            / "fixtures"
+            / "sample_component_definition.json"
+        )
+        with open(sample_path) as f:
+            return json.load(f)
+
+    @pytest.fixture
+    def setup_store(self, tmp_path, sample_component_def_data, monkeypatch):
+        _store._reset()
+        comp_defs_dir = tmp_path / "component_definitions"
+        comp_defs_dir.mkdir()
+        with open(comp_defs_dir / "sample.json", "w") as f:
+            json.dump(sample_component_def_data, f)
+
+        from mcp_server_for_oscal import config as config_module
+
+        monkeypatch.setattr(
+            config_module.config,
+            "component_definitions_dir",
+            str(comp_defs_dir),
+        )
+        _store.load_from_directory(comp_defs_dir)
+
+    def test_list_component_definitions_default_pagination(
+        self, mock_context, setup_store
+    ):
+        result = list_component_definitions(mock_context)
+        assert result["offset"] == 0
+        assert result["limit"] == 10
+
+    def test_list_components_default_pagination(
+        self, mock_context, setup_store
+    ):
+        result = list_components(mock_context)
+        assert result["offset"] == 0
+        assert result["limit"] == 10
+
+    def test_list_capabilities_default_pagination(
+        self, mock_context, tmp_path, monkeypatch
+    ):
+        _store._reset()
+        cap_path = (
+            Path(__file__).parent.parent
+            / "fixtures"
+            / "sample_component_definition_with_capabilities.json"
+        )
+        comp_defs_dir = tmp_path / "component_definitions"
+        comp_defs_dir.mkdir()
+        import shutil
+
+        shutil.copy(cap_path, comp_defs_dir / "cap.json")
+
+        from mcp_server_for_oscal import config as config_module
+
+        monkeypatch.setattr(
+            config_module.config,
+            "component_definitions_dir",
+            str(comp_defs_dir),
+        )
+        _store.load_from_directory(comp_defs_dir)
+
+        result = list_capabilities(mock_context)
+        assert result["offset"] == 0
+        assert result["limit"] == 10
 
 
 class TestGetCapability:


### PR DESCRIPTION
*Issue #84*
*Description of changes:*
- Add paginate() helper function in utils.py to slice lists and return standardized Page_Response envelope with items, total, offset, limit, and hasMore fields
- Update list_component_definitions, list_components, and list_capabilities tools to accept offset and limit parameters with defaults (offset=0, limit=10, max_limit=100)
- Add comprehensive test suite in test_paginate.py covering round-trip pagination, page size invariants, boundary conditions, and error handling
- Update test_query_component_definition.py to verify tool wrappers correctly integrate with paginate()
- Add Kiro specification files documenting requirements, design, and implementation tasks for pagination feature
- Prevents context window overflow when many OSCAL artifacts are loaded by enabling callers to fetch results in manageable pages




By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
