### PR TITLE
feat(oscal-store): Add post-copy hash verification to DB seeding

### DIFF
--- a/.kiro/specs/post-copy-db-verification/.config.kiro
+++ b/.kiro/specs/post-copy-db-verification/.config.kiro
@@ -1,0 +1,1 @@
+{"specId": "a3e37c35-ac61-44cd-a7e7-36dd147dbbed", "workflowType": "fast-task", "specType": "feature"}

--- a/.kiro/specs/post-copy-db-verification/design.md
+++ b/.kiro/specs/post-copy-db-verification/design.md
@@ -1,0 +1,210 @@
+# Design Document: Post-Copy DB Verification
+
+## Overview
+
+Add SHA-256 post-copy verification to all OscalStore database seeding paths, extract shared hash-reading logic into a helper, and remove the brittle hardcoded-count test.
+
+## Architecture
+
+The change is scoped to `OscalStore` in `oscal_store.py` and one test class in `test_build_oscal_db.py`. No new modules or public API changes.
+
+### Component Changes
+
+#### 1. New static method: `_get_expected_db_hash()`
+
+Extracts the hashes.json parsing logic currently duplicated in `_verify_bundled_db()` into a reusable helper.
+
+```python
+@staticmethod
+def _get_expected_db_hash() -> str | None:
+    """Read the expected SHA-256 hash for oscal_store.db from hashes.json.
+
+    Returns:
+        The expected hex digest string, or None if hashes.json is
+        missing, malformed, or lacks an entry for oscal_store.db.
+    """
+    if not BUNDLED_HASHES_PATH.exists():
+        logger.warning(
+            "hashes.json not found at %s; cannot verify DB",
+            BUNDLED_HASHES_PATH,
+        )
+        return None
+
+    try:
+        manifest = json.loads(BUNDLED_HASHES_PATH.read_text())
+    except (json.JSONDecodeError, OSError) as exc:
+        logger.warning("Failed to read hashes.json: %s", exc)
+        return None
+
+    expected = manifest.get("file_hashes", {}).get("oscal_store.db")
+    if not expected:
+        logger.warning("No hash entry for oscal_store.db in hashes.json")
+    return expected
+```
+
+#### 2. New static method: `_verify_file_hash()`
+
+Computes SHA-256 of a file and compares against the expected hash. Raises `RuntimeError` on mismatch and cleans up the file.
+
+```python
+@staticmethod
+def _verify_file_hash(file_path: Path, expected_hash: str) -> None:
+    """Verify a file's SHA-256 matches the expected hash.
+
+    Args:
+        file_path: Path to the file to verify.
+        expected_hash: Expected SHA-256 hex digest.
+
+    Raises:
+        RuntimeError: If the hash does not match.
+    """
+    h = hashlib.sha256()
+    with open(file_path, "rb") as f:
+        for chunk in iter(lambda: f.read(8192), b""):
+            h.update(chunk)
+
+    actual_hash = h.hexdigest()
+    if actual_hash != expected_hash:
+        file_path.unlink(missing_ok=True)
+        raise RuntimeError(
+            f"Post-copy integrity check failed for {file_path}: "
+            f"expected {expected_hash}, got {actual_hash}"
+        )
+```
+
+#### 3. Refactored `_verify_bundled_db()`
+
+Rewritten to use `_get_expected_db_hash()` and `_verify_file_hash()` internally, preserving the same return type (`bool`) and behavior.
+
+```python
+@staticmethod
+def _verify_bundled_db() -> bool:
+    """Verify the bundled DB SHA-256 against the hash in hashes.json."""
+    if not BUNDLED_DB_PATH.exists():
+        return False
+
+    expected_hash = OscalStore._get_expected_db_hash()
+    if not expected_hash:
+        return False
+
+    h = hashlib.sha256()
+    try:
+        with open(BUNDLED_DB_PATH, "rb") as f:
+            for chunk in iter(lambda: f.read(8192), b""):
+                h.update(chunk)
+    except OSError as exc:
+        logger.warning("Failed to read bundled DB for hashing: %s", exc)
+        return False
+
+    actual_hash = h.hexdigest()
+    if actual_hash != expected_hash:
+        logger.warning(
+            "Bundled DB integrity check failed: expected %s, got %s",
+            expected_hash,
+            actual_hash,
+        )
+        return False
+
+    logger.info("Bundled DB integrity verified")
+    return True
+```
+
+Note: `_verify_bundled_db` does NOT call `_verify_file_hash` directly because it must not delete the bundled DB on mismatch (it's a read-only package asset) and must return `bool` rather than raise. It shares only the hash-reading helper.
+
+#### 4. Modified `_resolve_persistent()`
+
+After `shutil.copy2`, call `_verify_file_hash()` on the copied file. If it raises `RuntimeError`, the error propagates up (fatal).
+
+```python
+def _resolve_persistent(self, db_path: str) -> str:
+    p = Path(db_path)
+    if p.exists():
+        self._db_mode = "persistent"
+        logger.info("Opening existing persistent DB at %s", db_path)
+        return db_path
+
+    if self._seed_from_bundled:
+        if BUNDLED_DB_PATH.exists() and self._verify_bundled_db():
+            try:
+                p.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copy2(BUNDLED_DB_PATH, p)
+            except OSError:
+                logger.warning(
+                    "Failed to copy bundled DB to %s; creating fresh DB",
+                    db_path,
+                )
+            else:
+                # Verify the copy's integrity
+                expected_hash = self._get_expected_db_hash()
+                if expected_hash:
+                    self._verify_file_hash(p, expected_hash)
+                self._db_mode = "persistent"
+                logger.info(
+                    "Seeded persistent DB from bundled DB at %s", db_path
+                )
+                return db_path
+
+    p.parent.mkdir(parents=True, exist_ok=True)
+    self._db_mode = "persistent"
+    logger.info("Creating new persistent DB at %s", db_path)
+    return db_path
+```
+
+#### 5. Modified `_copy_bundled_to_temp()`
+
+Same pattern: after `shutil.copy2`, verify the copy.
+
+```python
+def _copy_bundled_to_temp(self) -> str:
+    self._temp_dir = tempfile.TemporaryDirectory(prefix="oscal_store_")
+    dest = Path(self._temp_dir.name) / "oscal_store.db"
+    try:
+        shutil.copy2(BUNDLED_DB_PATH, dest)
+    except OSError:
+        logger.warning(
+            "Failed to copy bundled DB; falling back to ephemeral"
+        )
+        return self._create_ephemeral()
+
+    expected_hash = self._get_expected_db_hash()
+    if expected_hash:
+        self._verify_file_hash(dest, expected_hash)
+    self._db_mode = "bundled"
+    logger.info("Copied bundled DB to temp location %s", dest)
+    return str(dest)
+```
+
+### Test Changes
+
+#### Remove `test_new_path_with_bundled_db_seeds`
+
+Delete the entire method from `TestPreservationDefaultSeeding`. Update the class docstring to remove the reference to Requirement 3.1 and the hardcoded count test.
+
+#### Update class docstring
+
+```python
+class TestPreservationDefaultSeeding:
+    """Preservation: default OscalStore seeding behavior unchanged.
+
+    **Validates: Requirements 3.2, 3.3, 3.4**
+
+    These tests capture the existing correct behavior that must not regress
+    when the bugfix is applied. They MUST PASS on unfixed code.
+    """
+```
+
+## Error Handling
+
+- `_verify_file_hash()` raises `RuntimeError` on hash mismatch — this is intentionally fatal. Without an intact database, the server cannot perform as expected.
+- `_verify_file_hash()` calls `file_path.unlink(missing_ok=True)` before raising to clean up the corrupted copy.
+- If `_get_expected_db_hash()` returns `None` (missing manifest), the post-copy verification is skipped. The pre-copy `_verify_bundled_db()` check would have already caught this case and prevented the copy.
+
+## Correctness Properties
+
+*A property is a characteristic or behavior that should hold true across all valid executions of a system — essentially, a formal statement about what the system should do. Properties serve as the bridge between human-readable specifications and machine-verifiable correctness guarantees.*
+
+### Property 1: Hash mismatch raises RuntimeError and removes file
+
+*For any* file path and any pair of (expected_hash, actual_hash) where expected_hash differs from actual_hash, calling `_verify_file_hash` on that file SHALL raise a `RuntimeError` whose message contains both the expected hash and the actual hash and the file path, AND the file SHALL not exist after the error is raised.
+
+**Validates: Requirements 1.3, 1.4**

--- a/.kiro/specs/post-copy-db-verification/requirements.md
+++ b/.kiro/specs/post-copy-db-verification/requirements.md
@@ -1,0 +1,46 @@
+# Requirements Document
+
+## Introduction
+
+Add post-copy SHA-256 hash verification to all OscalStore database seeding paths. Currently, the bundled DB integrity is verified before copying but not after. A corrupted copy results in a silently broken server. This feature ensures every copied DB file is verified against the expected hash from `hashes.json` before use, and raises a fatal error on mismatch. Additionally, the brittle `test_new_path_with_bundled_db_seeds` test with a hardcoded document count is removed since runtime verification supersedes it.
+
+## Glossary
+
+- **OscalStore**: The SQLite-backed store class in `oscal_store.py` that manages all OSCAL model types.
+- **Bundled_DB**: The pre-built `oscal_store.db` file shipped with the package at `BUNDLED_DB_PATH`.
+- **Hashes_Manifest**: The `hashes.json` file at `BUNDLED_HASHES_PATH` containing expected SHA-256 hashes for bundled files.
+- **Post_Copy_Verification**: SHA-256 hash comparison of a copied file against the expected hash in the Hashes_Manifest.
+- **Seeding**: The process of copying the Bundled_DB to a new path to initialize a persistent or temporary database.
+
+## Requirements
+
+### Requirement 1
+
+**User Story:** As a server operator, I want the copied database file to be verified after copying, so that a corrupted copy is detected before the server uses it.
+
+#### Acceptance Criteria
+
+1. WHEN the OscalStore copies the Bundled_DB to a persistent path via `_resolve_persistent`, THE OscalStore SHALL compute the SHA-256 hash of the copied file and compare it against the expected hash from the Hashes_Manifest.
+2. WHEN the OscalStore copies the Bundled_DB to a temporary path via `_copy_bundled_to_temp`, THE OscalStore SHALL compute the SHA-256 hash of the copied file and compare it against the expected hash from the Hashes_Manifest.
+3. IF the Post_Copy_Verification fails (hash mismatch), THEN THE OscalStore SHALL raise a RuntimeError with a message containing the expected hash, the actual hash, and the destination path.
+4. IF the Post_Copy_Verification fails, THEN THE OscalStore SHALL remove the corrupted copy before raising the error.
+
+### Requirement 2
+
+**User Story:** As a developer, I want hash-reading logic extracted into a shared helper, so that hashes.json parsing is not duplicated across methods.
+
+#### Acceptance Criteria
+
+1. THE OscalStore SHALL provide a private method that reads the expected hash for `oscal_store.db` from the Hashes_Manifest and returns the hash string.
+2. THE `_verify_bundled_db` method SHALL use the shared hash-reading method instead of inline hashes.json parsing.
+3. THE Post_Copy_Verification logic SHALL use the same shared hash-reading method.
+
+### Requirement 3
+
+**User Story:** As a developer, I want the brittle hardcoded-count test removed, so that the test suite does not break when bundled DB content changes.
+
+#### Acceptance Criteria
+
+1. WHEN the test suite is executed, THE test suite SHALL NOT contain the `test_new_path_with_bundled_db_seeds` test method.
+2. THE `TestPreservationDefaultSeeding` class docstring SHALL remain accurate after the test removal.
+3. THE remaining tests in `TestPreservationDefaultSeeding` SHALL continue to pass without modification.

--- a/.kiro/specs/post-copy-db-verification/tasks.md
+++ b/.kiro/specs/post-copy-db-verification/tasks.md
@@ -1,0 +1,56 @@
+# Implementation Plan: Post-Copy DB Verification
+
+## Overview
+
+Extract shared hash-reading logic, add post-copy SHA-256 verification to both DB seeding paths, make verification failure fatal, and remove the brittle hardcoded-count test.
+
+## Tasks
+
+- [x] 1. Extract `_get_expected_db_hash()` and `_verify_file_hash()` static methods
+  - [x] 1.1 Add `_get_expected_db_hash()` static method to `OscalStore`
+    - Extract hashes.json parsing from `_verify_bundled_db()` into a new `@staticmethod` that returns `str | None`
+    - Place it above `_verify_bundled_db()` in the class
+    - _Requirements: 2.1_
+  - [x] 1.2 Add `_verify_file_hash()` static method to `OscalStore`
+    - Computes SHA-256 of a file, compares against expected hash
+    - On mismatch: calls `file_path.unlink(missing_ok=True)` then raises `RuntimeError` with expected hash, actual hash, and file path in the message
+    - _Requirements: 1.3, 1.4_
+  - [x] 1.3 Refactor `_verify_bundled_db()` to use `_get_expected_db_hash()`
+    - Replace inline hashes.json parsing with a call to `_get_expected_db_hash()`
+    - Preserve existing return type (`bool`) and behavior (does NOT delete bundled DB on mismatch)
+    - _Requirements: 2.2_
+
+- [x] 2. Add post-copy verification to `_resolve_persistent()`
+  - [x] 2.1 Add `_verify_file_hash()` call after `shutil.copy2` in `_resolve_persistent()`
+    - Use try/else pattern: `shutil.copy2` in try, verification in else block
+    - Get expected hash via `_get_expected_db_hash()`; if hash available, call `_verify_file_hash(p, expected_hash)`
+    - `RuntimeError` from `_verify_file_hash` propagates up (fatal)
+    - _Requirements: 1.1, 2.3_
+  - [ ]* 2.2 Write property test for `_verify_file_hash()`
+    - **Property 1: Hash mismatch raises RuntimeError and removes file**
+    - **Validates: Requirements 1.3, 1.4**
+
+- [x] 3. Add post-copy verification to `_copy_bundled_to_temp()`
+  - [x] 3.1 Add `_verify_file_hash()` call after `shutil.copy2` in `_copy_bundled_to_temp()`
+    - After successful copy, get expected hash and call `_verify_file_hash(dest, expected_hash)`
+    - `RuntimeError` propagates up (fatal)
+    - _Requirements: 1.2, 2.3_
+
+- [x] 4. Remove brittle test and update docstring
+  - [x] 4.1 Remove `test_new_path_with_bundled_db_seeds` from `TestPreservationDefaultSeeding`
+    - Delete the entire method (including `@given` and `@settings` decorators)
+    - _Requirements: 3.1_
+  - [x] 4.2 Update `TestPreservationDefaultSeeding` class docstring
+    - Remove reference to Requirement 3.1 from the `**Validates:**` line
+    - _Requirements: 3.2_
+
+- [x] 5. Checkpoint - Ensure all tests pass
+  - Run `hatch run tests` to verify all remaining tests pass
+  - Ensure all tests pass, ask the user if questions arise.
+  - _Requirements: 3.3_
+
+## Notes
+
+- Tasks marked with `*` are optional and can be skipped for faster MVP
+- The `_verify_bundled_db()` method intentionally does NOT use `_verify_file_hash()` because it must not delete the bundled DB (a read-only package asset) and returns `bool` instead of raising
+- Post-copy verification failure is fatal (`RuntimeError`) per user direction — without an intact DB, the server cannot serve customers correctly

--- a/src/mcp_server_for_oscal/tools/oscal_store.py
+++ b/src/mcp_server_for_oscal/tools/oscal_store.py
@@ -170,16 +170,21 @@ class OscalStore:
                 try:
                     p.parent.mkdir(parents=True, exist_ok=True)
                     shutil.copy2(BUNDLED_DB_PATH, p)
-                    self._db_mode = "persistent"
-                    logger.info(
-                        "Seeded persistent DB from bundled DB at %s", db_path
-                    )
-                    return db_path
                 except OSError:
                     logger.warning(
                         "Failed to copy bundled DB to %s; creating fresh DB",
                         db_path,
                     )
+                else:
+                    # Verify the copy's integrity
+                    expected_hash = self._get_expected_db_hash()
+                    if expected_hash:
+                        self._verify_file_hash(p, expected_hash)
+                    self._db_mode = "persistent"
+                    logger.info(
+                        "Seeded persistent DB from bundled DB at %s", db_path
+                    )
+                    return db_path
 
         # Create a new empty persistent DB
         p.parent.mkdir(parents=True, exist_ok=True)
@@ -209,14 +214,18 @@ class OscalStore:
         dest = Path(self._temp_dir.name) / "oscal_store.db"
         try:
             shutil.copy2(BUNDLED_DB_PATH, dest)
-            self._db_mode = "bundled"
-            logger.info("Copied bundled DB to temp location %s", dest)
-            return str(dest)
         except OSError:
             logger.warning(
                 "Failed to copy bundled DB; falling back to ephemeral"
             )
             return self._create_ephemeral()
+
+        expected_hash = self._get_expected_db_hash()
+        if expected_hash:
+            self._verify_file_hash(dest, expected_hash)
+        self._db_mode = "bundled"
+        logger.info("Copied bundled DB to temp location %s", dest)
+        return str(dest)
 
     def _create_ephemeral(self) -> str:
         """Create an ephemeral DB in a temporary directory."""
@@ -228,6 +237,56 @@ class OscalStore:
         self._db_mode = "ephemeral"
         logger.info("Creating ephemeral DB at %s", dest)
         return str(dest)
+
+    @staticmethod
+    def _get_expected_db_hash() -> str | None:
+        """Read the expected SHA-256 hash for oscal_store.db from hashes.json.
+
+        Returns:
+            The expected hex digest string, or None if hashes.json is
+            missing, malformed, or lacks an entry for oscal_store.db.
+        """
+        if not BUNDLED_HASHES_PATH.exists():
+            logger.warning(
+                "hashes.json not found at %s; cannot verify DB",
+                BUNDLED_HASHES_PATH,
+            )
+            return None
+
+        try:
+            manifest = json.loads(BUNDLED_HASHES_PATH.read_text())
+        except (json.JSONDecodeError, OSError) as exc:
+            logger.warning("Failed to read hashes.json: %s", exc)
+            return None
+
+        expected = manifest.get("file_hashes", {}).get("oscal_store.db")
+        if not expected:
+            logger.warning("No hash entry for oscal_store.db in hashes.json")
+        return expected
+
+    @staticmethod
+    def _verify_file_hash(file_path: Path, expected_hash: str) -> None:
+        """Verify a file's SHA-256 matches the expected hash.
+
+        Args:
+            file_path: Path to the file to verify.
+            expected_hash: Expected SHA-256 hex digest.
+
+        Raises:
+            RuntimeError: If the hash does not match.
+        """
+        h = hashlib.sha256()
+        with open(file_path, "rb") as f:
+            for chunk in iter(lambda: f.read(8192), b""):
+                h.update(chunk)
+
+        actual_hash = h.hexdigest()
+        if actual_hash != expected_hash:
+            file_path.unlink(missing_ok=True)
+            raise RuntimeError(
+                f"Post-copy integrity check failed for {file_path}: "
+                f"expected {expected_hash}, got {actual_hash}"
+            )
 
     @staticmethod
     def _verify_bundled_db() -> bool:
@@ -245,25 +304,8 @@ class OscalStore:
         if not BUNDLED_DB_PATH.exists():
             return False
 
-        if not BUNDLED_HASHES_PATH.exists():
-            logger.warning(
-                "hashes.json not found at %s; cannot verify bundled DB",
-                BUNDLED_HASHES_PATH,
-            )
-            return False
-
-        try:
-            manifest = json.loads(BUNDLED_HASHES_PATH.read_text())
-        except (json.JSONDecodeError, OSError) as exc:
-            logger.warning("Failed to read hashes.json: %s", exc)
-            return False
-
-        file_hashes = manifest.get("file_hashes", {})
-        expected_hash = file_hashes.get("oscal_store.db")
+        expected_hash = OscalStore._get_expected_db_hash()
         if not expected_hash:
-            logger.warning(
-                "No hash entry for oscal_store.db in hashes.json"
-            )
             return False
 
         h = hashlib.sha256()

--- a/tests/test_build_oscal_db.py
+++ b/tests/test_build_oscal_db.py
@@ -285,56 +285,11 @@ class TestBugConditionExploration:
 class TestPreservationDefaultSeeding:
     """Preservation: default OscalStore seeding behavior unchanged.
 
-    **Validates: Requirements 3.1, 3.2, 3.3, 3.4**
+    **Validates: Requirements 3.2, 3.3, 3.4**
 
     These tests capture the existing correct behavior that must not regress
     when the bugfix is applied. They MUST PASS on unfixed code.
     """
-
-    @given(
-        suffix=st.text(
-            min_size=1,
-            max_size=20,
-            alphabet=st.characters(whitelist_categories=("L", "N")),
-        )
-    )
-    @settings(max_examples=50, deadline=None)
-    def test_new_path_with_bundled_db_seeds(self, suffix: str) -> None:
-        """Default OscalStore(db_path=new_path) with valid bundled DB seeds the database.
-
-        **Validates: Requirements 3.1**
-
-        For all generated db_path strings (non-existent paths), default
-        OscalStore(db_path=path) with a valid bundled DB present seeds the
-        database (document count matches bundled DB count of 232).
-        """
-        from mcp_server_for_oscal.tools.oscal_store import (
-            BUNDLED_DB_PATH,
-            OscalStore,
-        )
-
-        # Skip if bundled DB is not present (can't test seeding without it)
-        if not BUNDLED_DB_PATH.exists():
-            pytest.skip("Bundled DB not present")
-
-        with tempfile.TemporaryDirectory() as tmpdir:
-            db_path = Path(tmpdir) / f"test_{suffix}.db"
-            store = OscalStore(db_path=str(db_path))
-            try:
-                doc_count = store._conn.execute(
-                    "SELECT COUNT(*) AS cnt FROM documents"
-                ).fetchone()["cnt"]
-
-                assert store._db_mode == "persistent", (
-                    f"Expected db_mode='persistent', got '{store._db_mode}'"
-                )
-                assert doc_count == 232, (
-                    f"Expected doc_count=232 (bundled DB count), "
-                    f"got doc_count={doc_count}. "
-                    f"Default seeding from bundled DB must be preserved."
-                )
-            finally:
-                store.close()
 
     @given(
         suffix=st.text(


### PR DESCRIPTION
Add SHA-256 post-copy verification to both OscalStore seeding paths (_resolve_persistent and _copy_bundled_to_temp) to detect corrupted copies before the server uses them. Extract shared hash-reading logic into _get_expected_db_hash() helper and add _verify_file_hash() for reusable file integrity checking.

Remove brittle test_new_path_with_bundled_db_seeds that hardcoded document count (232) which broke when bundled DB content changed. Runtime post-copy verification supersedes the test-time count check.

All tests pass (774 passed, 1 skipped on both Python 3.11 and 3.12).

#103

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
